### PR TITLE
Status: Minting. But: isMintingPossible: false

### DIFF
--- a/src/components/CoreSyncStatus.tsx
+++ b/src/components/CoreSyncStatus.tsx
@@ -88,7 +88,7 @@ export const CoreSyncStatus = () => {
         message = `${t(`core:minting.status.synchronizing`, { percent: syncPercent, postProcess: 'capitalizeFirstChar' })} ${t('core:minting.status.not_minting')}`;
       } else {
         imagePath = syncedImg;
-        message = `${t(`core:minting.status.synchronized`, { percent: syncPercent, postProcess: 'capitalizeFirstChar' })} ${t('core:minting.status.not_minting')}`;
+        message = `${t(`core:minting.status.synchronized`, { percent: syncPercent, postProcess: 'capitalizeFirstChar' })} ${t('core:minting.status.minting')}`;
       }
     } else if (isMintingPossible) {
       if (isSynchronizing) {


### PR DESCRIPTION
With this patch, the status that appear by hovering the Qotal icon (top left) shows: Minting.

Which is correct in my environment.

But if a log is placed here:

`
...
let imagePath = syncingImg;
let message: string = '';

console.log(`isSynchronizing: ${isSynchronizing}, syncPercent: ${syncPercent}, isMintingPossible: ${isMintingPossible}, height: ${height}, numberOfConnections: ${numberOfConnections} isUsingGateway: ${isUsingGateway}`);

if (isUsingGateway) {
...
`

What can be seen in the console is: 

`isSynchronizing: false, 
syncPercent: 100, 
**isMintingPossible: false**, 
height: 2218018, 
numberOfConnections: 132, 
isUsingGateway: true    
`

And, at this juncture, I also noticed that the number of connections is way bigger than the one reported in the node itself with, for example:

`curl --silent http://127.0.0.1:12391/admin/status |  tr -d { | tr -d } | tr -d \"`


