### PR TITLE
the getBaseApiReact() problem

### DIFF
--- a/src/components/CoreSyncStatus.tsx
+++ b/src/components/CoreSyncStatus.tsx
@@ -26,7 +26,10 @@ export const CoreSyncStatus = () => {
     const getNodeInfos = async () => {
       try {
         setIsUsingGateway(getBaseApiReact()?.includes('ext-node.qortal.link'));
-        const url = `${getBaseApiReact()}/admin/status`;
+
+        // const url = `${getBaseApiReact()}/admin/status`;
+        const url = "http://127.0.0.1:12391/admin/status";
+
         const response = await fetch(url, {
           method: 'GET',
           headers: {
@@ -81,6 +84,8 @@ export const CoreSyncStatus = () => {
 
     let imagePath = syncingImg;
     let message: string = '';
+
+    console.log('nodeInfos', nodeInfos);
 
     if (isUsingGateway) {
       if (isSynchronizing) {


### PR DESCRIPTION
At this portion:

> useEffect(() => {
>     const getNodeInfos = async () => {
>       try {
>         setIsUsingGateway(getBaseApiReact()?.includes('ext-node.qortal.link'));
>         // const url = '${getBaseApiReact()}/admin/status';
>         const url = "http://127.0.0.1:12391/admin/status";
>         const response = await fetch(url, {
>           method: 'GET',
>           headers: {
>             'Content-Type': 'application/json',
>           },
>         });
>         const data = await response.json();
>         setNodeInfos(data);
>       } catch (error) {
>         console.error('Request failed', error);
>       }
>     };
> 

The getBaseApiReact() is returning something that make no sense to me: "ext-node.qortal.link".

If it is replaced by: 

http://127.0.0.1:12391/admin/status 

all status info is correct: minting, sync, connections, etc...