### PR TITLE
Fix name fallback to use names/address

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -807,29 +807,37 @@ const forceCloseWebSocket = () => {
   }
 };
 
+const getFirstNameFromNamesResponse = (namesData) => {
+  if (Array.isArray(namesData) && namesData.length > 0) {
+    return namesData[0]?.name || '';
+  }
+  return '';
+};
+
+const getNameFromPrimaryOrFirst = async (address: string) => {
+  const validApi = await getBaseApi();
+  const response = await fetch(validApi + '/names/primary/' + address);
+  const nameData = await response.json().catch(() => null);
+  if (nameData?.name) {
+    return nameData.name;
+  }
+
+  const fallbackResponse = await fetch(
+    validApi + '/names/address/' + address + '?limit=0'
+  );
+  const names = await fallbackResponse.json().catch(() => null);
+  return getFirstNameFromNamesResponse(names);
+};
+
 export async function getNameInfo() {
   const wallet = await getSaveWallet();
   const address = wallet.address0;
-  const validApi = await getBaseApi();
-  const response = await fetch(validApi + '/names/primary/' + address);
-  const nameData = await response.json();
-  if (nameData?.name) {
-    return nameData.name;
-  } else {
-    return '';
-  }
+  return getNameFromPrimaryOrFirst(address);
 }
 
 export async function getNameInfoForOthers(address) {
   if (!address) return '';
-  const validApi = await getBaseApi();
-  const response = await fetch(validApi + '/names/primary/' + address);
-  const nameData = await response.json();
-  if (nameData?.name) {
-    return nameData?.name;
-  } else {
-    return '';
-  }
+  return getNameFromPrimaryOrFirst(address);
 }
 
 export async function getAddressInfo(address) {

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -277,15 +277,26 @@ export const getDataPublishesFunc = async (groupId, type) => {
   }
 };
 
+const getFirstNameFromNamesResponse = (namesData) => {
+  if (Array.isArray(namesData) && namesData.length > 0) {
+    return namesData[0]?.name || '';
+  }
+  return '';
+};
+
 export async function getNameInfo(address: string) {
   const response = await fetch(`${getBaseApiReact()}/names/primary/` + address);
-  const nameData = await response.json();
+  const nameData = await response.json().catch(() => null);
 
   if (nameData?.name) {
     return nameData?.name;
-  } else {
-    return '';
   }
+
+  const fallbackResponse = await fetch(
+    `${getBaseApiReact()}/names/address/` + address + '?limit=0'
+  );
+  const names = await fallbackResponse.json().catch(() => null);
+  return getFirstNameFromNamesResponse(names);
 }
 
 export const getGroupAdmins = async (groupNumber: number) => {

--- a/src/components/Minting/Minting.tsx
+++ b/src/components/Minting/Minting.tsx
@@ -128,7 +128,7 @@ export const Minting = ({ setIsOpenMinting, myAddress, show }) => {
     try {
       const url = `${getBaseApiReact()}/names/primary/${address}`;
       const response = await fetch(url);
-      const nameData = await response.json();
+      const nameData = await response.json().catch(() => null);
       if (nameData?.name) {
         setNames((prev) => {
           return {
@@ -137,10 +137,18 @@ export const Minting = ({ setIsOpenMinting, myAddress, show }) => {
           };
         });
       } else {
+        const fallbackResponse = await fetch(
+          `${getBaseApiReact()}/names/address/${address}?limit=0`
+        );
+        const names = await fallbackResponse.json().catch(() => null);
+        const fallbackName =
+          Array.isArray(names) && names.length > 0
+            ? names[0]?.name || null
+            : null;
         setNames((prev) => {
           return {
             ...prev,
-            [address]: null,
+            [address]: fallbackName,
           };
         });
       }

--- a/src/components/TaskManager/TaskManager.tsx
+++ b/src/components/TaskManager/TaskManager.tsx
@@ -132,9 +132,20 @@ export const TaskManager = ({ getUserInfo }) => {
         const response = await fetch(
           `${getBaseApiReact()}/names/primary/${address}`
         );
-        const nameData = await response.json();
+        const nameData = await response.json().catch(() => null);
 
         if (nameData?.name) {
+          getUserInfo();
+          return true;
+        }
+
+        const fallbackResponse = await fetch(
+          `${getBaseApiReact()}/names/address/${address}?limit=0`
+        );
+        const names = await fallbackResponse.json().catch(() => null);
+        const fallbackName =
+          Array.isArray(names) && names.length > 0 ? names[0]?.name || '' : '';
+        if (fallbackName) {
           getUserInfo();
           return true;
         }

--- a/src/encryption/encryption.ts
+++ b/src/encryption/encryption.ts
@@ -12,6 +12,13 @@ import { RequestQueueWithPromise } from '../utils/queue/queue.ts';
 
 export const requestQueueGetPublicKeys = new RequestQueueWithPromise(10);
 
+const getFirstNameFromNamesResponse = (namesData) => {
+  if (Array.isArray(namesData) && namesData.length > 0) {
+    return namesData[0]?.name || '';
+  }
+  return '';
+};
+
 async function getSaveWallet() {
   const res = await getData<any>('walletInfo').catch(() => null);
 
@@ -27,12 +34,16 @@ export async function getNameInfo() {
   const address = wallet.address0;
   const validApi = await getBaseApi();
   const response = await fetch(validApi + '/names/primary/' + address);
-  const nameData = await response.json();
+  const nameData = await response.json().catch(() => null);
   if (nameData?.name) {
     return nameData?.name;
-  } else {
-    return '';
   }
+
+  const fallbackResponse = await fetch(
+    validApi + '/names/address/' + address + '?limit=0'
+  );
+  const names = await fallbackResponse.json().catch(() => null);
+  return getFirstNameFromNamesResponse(names);
 }
 
 export async function getAllUserNames() {


### PR DESCRIPTION
## Problem
Hub currently treats `/names/primary/<address>` as the authoritative source for whether a user has a name. For accounts that have updated names but **no primary name set**, Core returns only the owner (`{"owner":"<address>"}`) and **no `name` field**. Hub interprets that as “no name,” which surfaces the red “REGISTER NAME” prompt and blocks features that require a name (e.g., Dev Mode preview, QDN publishing, avatars, and settings).

## Fix
Introduce a consistent fallback wherever `/names/primary/<address>` is used:
- If the primary-name response has no `name`, fetch `/names/address/<address>?limit=0`
- Use the **first entry’s `name`** (not the newest), per requirement

## Where This Is Applied
- `src/background/background.ts`: `getNameInfo` / `getNameInfoForOthers` (drives `userInfo.name`)
- `src/encryption/encryption.ts`: `getNameInfo` (publish flows)
- `src/components/Group/Group.tsx`: `getNameInfo` for member/admin display
- `src/components/TaskManager/TaskManager.tsx`: register-name polling
- `src/components/Minting/Minting.tsx`: name display in minting view

## Behavior After Fix
Accounts with non-primary names are treated as having a name again:
- Home screen no longer shows “REGISTER NAME”
- Dev Mode preview and name-gated flows work
- Group/minting name lookups populate correctly