### PR TITLE
Add persistent Qortal nav/search bar with identifier-safe routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,7 @@ import {
   CUSTOM_TITLE_BAR_HEIGHT,
 } from './components/Desktop/CustomTitleBar';
 import { roundUpToDecimals } from './utils/numberFunctions.ts';
+import { GlobalQortalNavBar } from './components/Desktop/GlobalQortalNavBar.tsx';
 
 // Re-export for consumers that still import from App
 export type { extStates } from './types/app';
@@ -1348,6 +1349,9 @@ function App() {
       }}
     >
       <CustomTitleBar rightNav={titleBarRightNav} />
+      {extState === 'authenticated' && isMainWindow && (
+        <GlobalQortalNavBar desktopViewMode={desktopViewMode} />
+      )}
 
       <Box
         sx={{

--- a/src/components/App/AuthenticatedShell.tsx
+++ b/src/components/App/AuthenticatedShell.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@mui/material';
 import { Group } from '../Group/Group';
 import { AuthenticatedProfile } from '../Profile';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
 
 /**
  * Authenticated main layout: Group (left) + AuthenticatedProfile (right).
@@ -68,12 +67,29 @@ export function AuthenticatedShell({
 }: AuthenticatedShellProps) {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         display: 'flex',
         flexDirection: 'row',
-        height: `calc(100vh - ${appHeighOffsetPx})`,
+        height: '100%',
+        isolation: 'isolate',
+        position: 'relative',
         width: '100vw',
-      }}
+        '&::before': {
+          background:
+            theme.palette.mode === 'dark'
+              ? 'linear-gradient(to bottom, rgba(16, 18, 22, 0.16), rgba(16, 18, 22, 0.09))'
+              : 'linear-gradient(to bottom, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.08))',
+          content: '""',
+          inset: 0,
+          pointerEvents: 'none',
+          position: 'absolute',
+          zIndex: 0,
+        },
+        '& > *': {
+          position: 'relative',
+          zIndex: 1,
+        },
+      })}
     >
       <Group
         desktopViewMode={desktopViewMode}

--- a/src/components/Apps/AppViewer.tsx
+++ b/src/components/Apps/AppViewer.tsx
@@ -6,8 +6,8 @@ import { useFrame } from 'react-frame-component';
 import { useQortalMessageListener } from '../../hooks/useQortalMessageListener';
 import { useThemeContext } from '../Theme/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import { QORTAL_PROTOCOL } from '../../constants/constants';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
+import { buildQortalResourceLink } from '../../utils/qortalLink';
 
 type AppViewerProps = {
   app: any;
@@ -27,6 +27,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
         isDevMode,
         isDevMode ? 'devapp' : app?.name,
         app?.service,
+        app?.identifier,
         skipAuth
       );
 
@@ -133,8 +134,11 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
     const copyLinkFunc = (e) => {
       const { tabId } = e.detail;
       if (tabId === app?.tabId) {
-        let link =
-          QORTAL_PROTOCOL + app?.service + '/' + app?.name.replace(/ /g, '%20');
+        let link = buildQortalResourceLink({
+          service: app?.service,
+          name: app?.name,
+          identifier: app?.identifier,
+        });
         if (path && path.startsWith('/')) {
           link = link + removeTrailingSlash(path);
         }
@@ -325,6 +329,25 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
       }
     };
 
+    const navigateForwardAppFunc = () => {
+      navigateForwardInIframe();
+    };
+
+    useEffect(() => {
+      if (!app?.tabId) return;
+      subscribeToEvent(
+        `navigateForwardApp-${app?.tabId}`,
+        navigateForwardAppFunc
+      );
+
+      return () => {
+        unsubscribeFromEvent(
+          `navigateForwardApp-${app?.tabId}`,
+          navigateForwardAppFunc
+        );
+      };
+    }, [app?.tabId]);
+
     return (
       <Box
         sx={{
@@ -335,7 +358,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
         <iframe
           ref={iframeRef}
           style={{
-            height: `100vh`,
+            height: `calc(100vh - ${appChromeOffsetPx})`,
             border: 'none',
             width: '100%',
           }}

--- a/src/components/Apps/AppViewerContainer.tsx
+++ b/src/components/Apps/AppViewerContainer.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { AppViewer } from './AppViewer';
 import Frame from 'react-frame-component';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 type AppViewerContainerProps = {
   app: any;
@@ -44,7 +44,7 @@ const AppViewerContainer = forwardRef<
       }
       style={{
         border: 'none',
-        height: customHeight || `calc(100vh - ${appHeighOffsetPx})`,
+        height: customHeight || `calc(100vh - ${appChromeOffsetPx})`,
         left: (!isSelected || hide) && '-200vw',
         overflow: 'hidden',
         position: (!isSelected || hide) && 'fixed',

--- a/src/components/Apps/AppsCategoryDesktop.tsx
+++ b/src/components/Apps/AppsCategoryDesktop.tsx
@@ -22,8 +22,7 @@ import { ReturnIcon } from '../../assets/Icons/ReturnIcon';
 import { useAtom } from 'jotai';
 import { appSortAtom } from '../../atoms/appsAtoms';
 import { SortDropdown, SortOption } from './Filters';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 // Sorting function (same as CommunityAppsTab)
 const sortApps = (apps: any[], sortOption: SortOption): any[] => {
@@ -104,7 +103,7 @@ export const AppsCategoryDesktop = ({
     <AppsLibraryContainer
       sx={{
         display: !isShow && 'none',
-        height: `calc(100vh - ${appHeighOffsetPx} )`,
+        height: `calc(100vh - ${appChromeOffsetPx} )`,
         overflow: 'hidden',
         padding: '0px',
         paddingTop: '30px',
@@ -190,12 +189,12 @@ export const AppsCategoryDesktop = ({
       </AppsDesktopLibraryHeader>
 
       <AppsDesktopLibraryBody
-        sx={{
-          alignItems: 'center',
-          height: `calc(100vh - ${appHeighOffsetPx}  - 36px)`,
-          overflow: 'auto',
-          padding: '0px',
-          width: '90%',
+      sx={{
+        alignItems: 'center',
+        height: `calc(100vh - ${appChromeOffsetPx}  - 36px)`,
+        overflow: 'auto',
+        padding: '0px',
+        width: '90%',
           maxWidth: '1200px',
         }}
       >

--- a/src/components/Apps/AppsDesktop.tsx
+++ b/src/components/Apps/AppsDesktop.tsx
@@ -32,7 +32,6 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  useTheme,
 } from '@mui/material';
 import {
   enabledDevModeAtom,
@@ -43,8 +42,7 @@ import { publishEditTargetAtom } from '../../atoms/appsAtoms';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { TIME_MINUTES_20_IN_MILLISECONDS } from '../../constants/constants';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 const uid = new ShortUniqueId({ length: 8 });
 
@@ -65,9 +63,12 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
   const [isEnabledDevMode, setIsEnabledDevMode] = useAtom(enabledDevModeAtom);
   const { showTutorial } = useHandleTutorials();
   const { refreshRatings } = useAppRatings();
-  const theme = useTheme();
   const [showCloseTabDialog, setShowCloseTabDialog] = useState(false);
   const [pendingTabToRemove, setPendingTabToRemove] = useState(null);
+  const [librarySearchRequest, setLibrarySearchRequest] = useState<{
+    nonce: number;
+    query: string;
+  }>({ nonce: 0, query: '' });
   const { t } = useTranslation([
     'auth',
     'core',
@@ -428,6 +429,28 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
     };
   }, [tabs]);
 
+  const openAppsLibrarySearchFunc = useCallback((e) => {
+    const query = e.detail?.data?.query || '';
+    setSelectedTab(null);
+    setIsNewTabWindow(false);
+    setLibrarySearchRequest({
+      nonce: Date.now(),
+      query,
+    });
+    setMode('library');
+  }, []);
+
+  useEffect(() => {
+    subscribeToEvent('openAppsLibrarySearch', openAppsLibrarySearchFunc);
+
+    return () => {
+      unsubscribeFromEvent(
+        'openAppsLibrarySearch',
+        openAppsLibrarySearchFunc
+      );
+    };
+  }, [openAppsLibrarySearchFunc]);
+
   return (
     <AppsParent
       sx={{
@@ -442,7 +465,7 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            height: `calc(100vh - ${appHeighOffsetPx} )`,
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
             overflow: 'auto',
             width: '100%',
           }}
@@ -463,6 +486,7 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
       <AppsLibraryDesktop
         availableQapps={availableQapps}
         categories={categories}
+        externalSearchRequest={librarySearchRequest}
         getQapps={async () => { await getQapps(); refreshRatings(); }}
         hasPublishApp={!!(myApp || myWebsite)}
         isShow={mode === 'library' && !selectedTab}
@@ -527,12 +551,12 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
         <>
           <Box
             sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: `calc(100vh - ${appHeighOffsetPx} )`,
-              overflow: 'auto',
-              width: '100%',
-            }}
+            display: 'flex',
+            flexDirection: 'column',
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
+            overflow: 'auto',
+            width: '100%',
+          }}
           >
             <Spacer height="30px" />
 

--- a/src/components/Apps/AppsDevMode.tsx
+++ b/src/components/Apps/AppsDevMode.tsx
@@ -11,10 +11,9 @@ import {
 import { AppsParent } from './Apps-styles';
 import AppViewerContainer from './AppViewerContainer';
 import ShortUniqueId from 'short-unique-id';
-import { Box, useTheme } from '@mui/material';
+import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 const uid = new ShortUniqueId({ length: 8 });
 
@@ -44,7 +43,6 @@ export const AppsDevMode = ({
   const [isNewTabWindow, setIsNewTabWindow] = useState(false);
   const [categories, setCategories] = useState([]);
   const iframeRefs = useRef({});
-  const theme = useTheme();
   const { t } = useTranslation([
     'auth',
     'core',
@@ -229,7 +227,7 @@ export const AppsDevMode = ({
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            height: `calc(100vh - ${appHeighOffsetPx} )`,
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
             overflow: 'auto',
             width: 'auto',
           }}
@@ -265,13 +263,13 @@ export const AppsDevMode = ({
       {isNewTabWindow && mode === 'viewer' && (
         <>
           <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: `calc(100vh - ${appHeighOffsetPx} )`,
-              overflow: 'auto',
-              width: 'auto',
-            }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
+            overflow: 'auto',
+            width: 'auto',
+          }}
           >
             <Spacer height="30px" />
 

--- a/src/components/Apps/AppsLibraryDesktop.tsx
+++ b/src/components/Apps/AppsLibraryDesktop.tsx
@@ -25,6 +25,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import IconClearInput from '../../assets/svgs/ClearInput.svg';
 import { useAtom } from 'jotai';
 import { appSortAtom } from '../../atoms/appsAtoms';
+import { filterAndSortApps } from '../../atoms/appsAtoms';
 import {
   SortDropdown,
   CategoryFilter,
@@ -40,8 +41,8 @@ import {
   MyAppsTab,
   PrivateTab,
 } from './AppsLibrary';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
+import { AppCardEnhanced } from './AppCard';
 
 const SearchContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -62,6 +63,7 @@ export const AppsLibraryDesktop = ({
   isShow,
   categories,
   getQapps,
+  externalSearchRequest,
 }) => {
   const [currentTab, setCurrentTab] = useState<AppsLibraryTabValue>('official');
   const [searchValue, setSearchValue] = useState('');
@@ -85,11 +87,69 @@ export const AppsLibraryDesktop = ({
     return () => clearTimeout(handler);
   }, [searchValue]);
 
+  useEffect(() => {
+    if (!externalSearchRequest?.query) return;
+    setSearchValue(externalSearchRequest.query);
+    setDebouncedSearchValue(externalSearchRequest.query);
+  }, [externalSearchRequest?.nonce]);
+
   const handleTabChange = (tab: AppsLibraryTabValue) => {
     setCurrentTab(tab);
   };
 
   const renderTabContent = () => {
+    if (debouncedSearchValue.trim()) {
+      const combinedResults = filterAndSortApps(availableQapps, {
+        sort: sortOption,
+        category: 'all',
+        status: 'all',
+        search: debouncedSearchValue,
+      });
+
+      return (
+        <AppsWidthLimiter>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+            }}
+          >
+            <Box
+              sx={{
+                color: theme.palette.text.primary,
+                fontSize: '20px',
+                fontWeight: 600,
+              }}
+            >
+              {t('core:action.search_apps', {
+                postProcess: 'capitalizeFirstChar',
+              })}{' '}
+              ({combinedResults.length})
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gap: '16px',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+              width: '100%',
+            }}
+          >
+            {combinedResults.map((app) => (
+              <AppCardEnhanced
+                key={`${app?.service}-${app?.name}`}
+                app={app}
+                myName={myName}
+              />
+            ))}
+          </Box>
+        </AppsWidthLimiter>
+      );
+    }
+
     switch (currentTab) {
       case 'official':
         return (
@@ -146,7 +206,7 @@ export const AppsLibraryDesktop = ({
       sx={{
         display: !isShow && 'none',
         padding: '0px',
-        height: `calc(100vh - ${appHeighOffsetPx} )`,
+        height: `calc(100vh - ${appChromeOffsetPx} )`,
         overflow: 'hidden',
         paddingTop: '30px',
       }}

--- a/src/components/Chat/MessageDisplay.tsx
+++ b/src/components/Chat/MessageDisplay.tsx
@@ -23,19 +23,31 @@ export const extractComponents = (url: string) => {
   // If nothing meaningful left (e.g., "qortal://", "qortal:////"), return null
   if (!/[^/]/.test(url)) return null;
 
-  // Case 1: url contains a slash → already service-based
+  // Case 1: url contains a slash -> already service-based
   if (url.includes('/')) {
-    const parts = url.split('/');
+    // Identifier is part of QDN resource identity when present. Keep older
+    // links without identifier working, and route future reopen flows here.
+    const [basePart, queryString = ''] = url.split('?');
+    const parts = basePart.split('/');
     const service = parts[0].toUpperCase();
     parts.shift();
     const name = parts[0];
     parts.shift();
-    let identifier;
-    const path = parts.join('/');
+
+    const params = new URLSearchParams(queryString);
+    const identifier = params.get('identifier') || undefined;
+    if (identifier) {
+      params.delete('identifier');
+    }
+
+    const remainingQuery = params.toString();
+    const basePath = parts.join('/');
+    const path = `${basePath}${remainingQuery ? `?${remainingQuery}` : ''}`;
+
     return { service, name, identifier, path };
   }
 
-  // Case 2: url is just a username → default to WEBSITE
+  // Case 2: url is just a username -> default to WEBSITE
   return {
     service: 'WEBSITE',
     name: url,
@@ -78,7 +90,7 @@ function processText(input) {
 }
 
 const linkify = (text) => {
-  if (!text) return ''; // Return an empty string if text is null or undefined
+  if (!text) return '';
   let textFormatted = text;
   const urlPattern = /(\bhttps?:\/\/[^\s<]+|\bwww\.[^\s<]+)/g;
   textFormatted = text.replace(urlPattern, (url) => {
@@ -158,7 +170,12 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
   const handleClickCapture = (e) => {
     if (isReply) {
       const target = e.target;
-      const isLink = target.tagName === 'A' || target.getAttribute?.('data-url') || target.closest?.('a') || target.closest?.('.qortal-link') || target.closest?.('[data-url]');
+      const isLink =
+        target.tagName === 'A' ||
+        target.getAttribute?.('data-url') ||
+        target.closest?.('a') ||
+        target.closest?.('.qortal-link') ||
+        target.closest?.('[data-url]');
       if (isLink) {
         e.preventDefault();
         e.stopPropagation();
@@ -170,7 +187,12 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
     if (isReply) {
       e.preventDefault();
       const target = e.target;
-      const isLink = target.tagName === 'A' || target.getAttribute?.('data-url') || target.closest?.('a') || target.closest?.('.qortal-link') || target.closest?.('[data-url]');
+      const isLink =
+        target.tagName === 'A' ||
+        target.getAttribute?.('data-url') ||
+        target.closest?.('a') ||
+        target.closest?.('.qortal-link') ||
+        target.closest?.('[data-url]');
       if (isLink) {
         e.stopPropagation();
         return;
@@ -195,12 +217,11 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
       try {
         copyUrl = copyUrl.replace(/^(qortal:\/\/)/, '');
         if (copyUrl.startsWith('use-')) {
-          // Handle the new 'use' format
           const parts = copyUrl.split('/');
           parts.shift();
-          const action = parts.length > 0 ? parts[0].split('-')[1] : null; // e.g., 'invite' from 'action-invite'
+          const action = parts.length > 0 ? parts[0].split('-')[1] : null;
           parts.shift();
-          const id = parts.length > 0 ? parts[0].split('-')[1] : null; // e.g., '321' from 'groupid-321'
+          const id = parts.length > 0 ? parts[0].split('-')[1] : null;
           if (action === 'join') {
             executeEvent('globalActionJoinGroup', { groupId: id });
             return;

--- a/src/components/Desktop/CustomTitleBar.tsx
+++ b/src/components/Desktop/CustomTitleBar.tsx
@@ -27,12 +27,15 @@ import { GlobalActions } from '../GlobalActions/GlobalActions';
 import { ChatWidgetReopenIcon } from '../Profile/ChatWidgetReopenIcon';
 
 const TITLE_BAR_HEIGHT = 32;
+export const APP_NAV_BAR_HEIGHT = 48;
 /** Left offset so title-bar nav aligns with content vertical line (DesktopLeftSideBar width). */
 const TITLE_BAR_LEFT_OFFSET_PX = 70;
 const TITLE_BAR_MENU_WIDTH_PX = 40;
 export const CUSTOM_TITLE_BAR_HEIGHT = TITLE_BAR_HEIGHT;
 export const appHeighOffsetPx = `${TITLE_BAR_HEIGHT}px`;
 export const appHeighOffset = TITLE_BAR_HEIGHT;
+export const appChromeOffsetPx = `${TITLE_BAR_HEIGHT + APP_NAV_BAR_HEIGHT}px`;
+export const appChromeOffset = TITLE_BAR_HEIGHT + APP_NAV_BAR_HEIGHT;
 declare global {
   interface Window {
     electronAPI?: {

--- a/src/components/Desktop/DesktopLeftSideBar.tsx
+++ b/src/components/Desktop/DesktopLeftSideBar.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { AppsNavBarDesktop } from '../Apps/AppsNavBarDesktop';
 import { AppsDevModeNavBar } from '../Apps/AppsDevModeNavBar';
 import { executeEvent } from '../../utils/events';
-import { appHeighOffsetPx } from './CustomTitleBar';
+import { appChromeOffsetPx } from './CustomTitleBar';
 
 export const DesktopSideBar = ({
   goToHome,
@@ -55,7 +55,7 @@ export const DesktopSideBar = ({
         display: 'flex',
         flexDirection: 'column',
         gap: '25px',
-        height: `calc(100vh - ${appHeighOffsetPx})`,
+        height: `calc(100vh - ${appChromeOffsetPx})`,
         width: 'auto', // must adapt to the chosen language
       }}
     >

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -45,7 +45,10 @@ export function GlobalQortalNavBar({
   const { t } = useTranslation(['core']);
   const [selectedTab, setSelectedTab] = useState<SelectedTab>(null);
   const [inputValue, setInputValue] = useState('');
+  const [isInputHovered, setIsInputHovered] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const isInputFocusedRef = useRef(false);
+  const inputElementRef = useRef<HTMLInputElement | null>(null);
 
   const setTabsToNav = useCallback((e: CustomEvent) => {
     const nextSelectedTab = e.detail?.data?.selectedTab;
@@ -118,8 +121,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.82)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(70, 73, 79, 0.96)'
-      : 'rgba(255, 255, 255, 0.9)';
+      ? 'rgba(68, 71, 77, 0.94)'
+      : 'rgba(255, 255, 255, 0.88)';
   const hoverBorderColor =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.16)'
@@ -130,16 +133,46 @@ export function GlobalQortalNavBar({
       : 'rgba(0, 0, 0, 0.2)';
   const inputHoverShadow =
     theme.palette.mode === 'dark'
-      ? '0 0 0 1px rgba(255, 255, 255, 0.03), 0 8px 18px rgba(0, 0, 0, 0.14)'
-      : '0 0 0 1px rgba(255, 255, 255, 0.08), 0 8px 18px rgba(120, 127, 140, 0.12)';
+      ? `0 0 0 1px rgba(94, 154, 255, 0.3), 0 0 0 3px rgba(94, 154, 255, 0.12)`
+      : `0 0 0 1px rgba(41, 121, 218, 0.28), 0 0 0 3px rgba(41, 121, 218, 0.1)`;
   const inputFocusShadow =
     theme.palette.mode === 'dark'
-      ? '0 0 0 1px rgba(255, 255, 255, 0.06), 0 10px 24px rgba(0, 0, 0, 0.2)'
-      : '0 0 0 1px rgba(255, 255, 255, 0.12), 0 10px 24px rgba(120, 127, 140, 0.16)';
+      ? 'none'
+      : 'none';
   const buttonHoverBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.06)'
       : 'rgba(0, 0, 0, 0.05)';
+  const inputTextDefaultColor = theme.palette.text.secondary;
+  const inputTextHoverColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(224, 224, 224, 0.92)'
+      : 'rgba(0, 0, 0, 0.72)';
+  const inputTextFocusColor = theme.palette.text.primary;
+  const inputTextColor = isInputFocused
+    ? inputTextFocusColor
+    : isInputHovered
+      ? inputTextHoverColor
+      : inputTextDefaultColor;
+  const placeholderColor = isInputFocused
+    ? inputTextHoverColor
+    : theme.palette.text.secondary;
+  const selectionBackground = theme.palette.primary.main;
+  const selectionColor =
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.92)' : '#ffffff';
+  const showStyledLinkPreview =
+    !isInputFocused && !!inputValue && /^qortal:\/\//i.test(inputValue);
+  const protocolMatch = inputValue.match(/^(qortal:\/\/)/i);
+  const protocolText = protocolMatch?.[0] || '';
+  const remainderText = protocolText ? inputValue.slice(protocolText.length) : '';
+  const protocolColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(224, 224, 224, 0.92)'
+      : 'rgba(0, 0, 0, 0.74)';
+  const remainderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(176, 176, 176, 0.9)'
+      : 'rgba(0, 0, 0, 0.56)';
 
   return (
     <Box
@@ -200,11 +233,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canGoBack ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -226,11 +258,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canGoForward ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -258,11 +289,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canRefresh ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -271,6 +301,8 @@ export function GlobalQortalNavBar({
         </Box>
 
         <Box
+          onMouseEnter={() => setIsInputHovered(true)}
+          onMouseLeave={() => setIsInputHovered(false)}
           sx={{
             alignItems: 'center',
             backgroundColor: inputBackground,
@@ -284,18 +316,16 @@ export function GlobalQortalNavBar({
             px: 1.5,
             boxShadow: 'none',
             transition:
-              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease, transform 280ms ease',
+              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease',
             '&:hover': {
               backgroundColor: inputHoverBackground,
               borderColor: hoverBorderColor,
               boxShadow: inputHoverShadow,
-              transform: 'translateY(-1px)',
             },
             '&:focus-within': {
               backgroundColor: inputFocusBackground,
               borderColor: focusBorderColor,
               boxShadow: inputFocusShadow,
-              transform: 'translateY(-1px)',
             },
           }}
         >
@@ -305,38 +335,99 @@ export function GlobalQortalNavBar({
               fontSize: 17,
             }}
           />
-          <InputBase
-            value={inputValue}
-            onBlur={() => {
-              isInputFocusedRef.current = false;
-            }}
-            onChange={(e) => setInputValue(e.target.value)}
-            onFocus={() => {
-              isInputFocusedRef.current = true;
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleOpenInput();
-              }
-            }}
-            placeholder={t('core:action.search_apps_or_link', {
-              postProcess: 'capitalizeFirstChar',
-            })}
+          <Box
             sx={{
-              color: theme.palette.text.primary,
+              alignItems: 'center',
+              display: 'flex',
               flex: 1,
-              fontSize: '13.5px',
               minWidth: 0,
-              '& .MuiInputBase-input': {
-                py: '6px',
-              },
-              '& .MuiInputBase-input::placeholder': {
-                color: theme.palette.text.secondary,
-                opacity: 1,
-              },
+              position: 'relative',
             }}
-          />
+          >
+            {showStyledLinkPreview && (
+              <Box
+                aria-hidden
+                sx={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  inset: 0,
+                  overflow: 'hidden',
+                  pointerEvents: 'none',
+                  position: 'absolute',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <Box
+                  component="span"
+                  sx={{
+                    color: protocolColor,
+                    fontSize: '13.5px',
+                    transition: 'color 220ms ease',
+                  }}
+                >
+                  {protocolText}
+                </Box>
+                <Box
+                  component="span"
+                  sx={{
+                    color: remainderColor,
+                    fontSize: '13.5px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    transition: 'color 220ms ease',
+                  }}
+                >
+                  {remainderText}
+                </Box>
+              </Box>
+            )}
+            <InputBase
+              inputRef={inputElementRef}
+              value={inputValue}
+              onBlur={() => {
+                isInputFocusedRef.current = false;
+                setIsInputFocused(false);
+              }}
+              onChange={(e) => setInputValue(e.target.value)}
+              onFocus={() => {
+                isInputFocusedRef.current = true;
+                setIsInputFocused(true);
+                window.setTimeout(() => {
+                  inputElementRef.current?.select();
+                }, 0);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleOpenInput();
+                }
+              }}
+              placeholder={t('core:action.search_apps_or_link', {
+                postProcess: 'capitalizeFirstChar',
+              })}
+              sx={{
+                color: inputTextColor,
+                flex: 1,
+                fontSize: '13.5px',
+                minWidth: 0,
+                transition: 'color 220ms ease',
+                '& .MuiInputBase-input': {
+                  color: showStyledLinkPreview ? 'transparent' : 'inherit',
+                  py: '6px',
+                  transition: 'color 220ms ease',
+                  '::selection': {
+                    backgroundColor: selectionBackground,
+                    color: selectionColor,
+                  },
+                },
+                '& .MuiInputBase-input::placeholder': {
+                  color: placeholderColor,
+                  opacity: 1,
+                  transition: 'color 220ms ease',
+                },
+              }}
+            />
+          </Box>
           <ButtonBase
             onClick={handleOpenInput}
             sx={{
@@ -348,12 +439,11 @@ export function GlobalQortalNavBar({
               height: 26,
               justifyContent: 'center',
               transition:
-                'background-color 180ms ease, color 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease',
               width: 26,
               '&:hover': {
                 backgroundColor: buttonHoverBackground,
                 color: theme.palette.text.primary,
-                transform: 'translateY(-1px)',
               },
             }}
           >

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -173,6 +173,12 @@ export function GlobalQortalNavBar({
     theme.palette.mode === 'dark'
       ? 'rgba(176, 176, 176, 0.9)'
       : 'rgba(0, 0, 0, 0.56)';
+  const linkTextMetrics = {
+    fontSize: '13.5px',
+    fontWeight: 400,
+    letterSpacing: 'normal',
+    lineHeight: '20px',
+  } as const;
 
   return (
     <Box
@@ -361,8 +367,11 @@ export function GlobalQortalNavBar({
                   component="span"
                   sx={{
                     color: protocolColor,
-                    fontSize: '13.5px',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    height: '20px',
                     transition: 'color 220ms ease',
+                    ...linkTextMetrics,
                   }}
                 >
                   {protocolText}
@@ -370,11 +379,14 @@ export function GlobalQortalNavBar({
                 <Box
                   component="span"
                   sx={{
+                    alignItems: 'center',
                     color: remainderColor,
-                    fontSize: '13.5px',
+                    display: 'inline-flex',
+                    height: '20px',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     transition: 'color 220ms ease',
+                    ...linkTextMetrics,
                   }}
                 >
                   {remainderText}
@@ -408,13 +420,20 @@ export function GlobalQortalNavBar({
               sx={{
                 color: inputTextColor,
                 flex: 1,
-                fontSize: '13.5px',
                 minWidth: 0,
                 transition: 'color 220ms ease',
+                ...linkTextMetrics,
                 '& .MuiInputBase-input': {
+                  appearance: 'none',
+                  boxSizing: 'border-box',
                   color: showStyledLinkPreview ? 'transparent' : 'inherit',
-                  py: '6px',
+                  display: 'block',
+                  height: '20px',
+                  lineHeight: '20px',
+                  margin: 0,
+                  padding: 0,
                   transition: 'color 220ms ease',
+                  ...linkTextMetrics,
                   '::selection': {
                     backgroundColor: selectionBackground,
                     color: selectionColor,

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -86,8 +86,10 @@ export function GlobalQortalNavBar({
     const trimmed = inputValue.trim();
     if (!trimmed) return;
 
-    const normalized = normalizeQortalInput(trimmed);
-    const parsedLink = extractComponents(normalized);
+    const isExplicitQortalLink = /^qortal:\/\//i.test(trimmed);
+    const parsedLink = isExplicitQortalLink
+      ? extractComponents(normalizeQortalInput(trimmed))
+      : null;
 
     if (parsedLink) {
       const { service, name, identifier, path } = parsedLink;
@@ -117,8 +119,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.72)';
   const inputHoverBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(69, 82, 108, 0.94)'
-      : 'rgba(205, 223, 244, 0.92)';
+      ? 'rgba(62, 78, 108, 0.96)'
+      : 'rgba(194, 216, 242, 0.94)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(68, 71, 77, 0.94)'
@@ -144,8 +146,8 @@ export function GlobalQortalNavBar({
   const inputTextDefaultColor = theme.palette.text.secondary;
   const inputTextHoverColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(224, 224, 224, 0.92)'
-      : 'rgba(0, 0, 0, 0.72)';
+      ? 'rgba(236, 240, 246, 0.96)'
+      : 'rgba(0, 0, 0, 0.78)';
   const inputTextFocusColor = theme.palette.text.primary;
   const inputTextColor = isInputFocused
     ? inputTextFocusColor
@@ -165,12 +167,20 @@ export function GlobalQortalNavBar({
   const remainderText = protocolText ? inputValue.slice(protocolText.length) : '';
   const protocolColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(224, 224, 224, 0.92)'
-      : 'rgba(0, 0, 0, 0.74)';
+      ? isInputHovered
+        ? 'rgba(242, 246, 252, 0.98)'
+        : 'rgba(224, 224, 224, 0.92)'
+      : isInputHovered
+        ? 'rgba(0, 0, 0, 0.82)'
+        : 'rgba(0, 0, 0, 0.74)';
   const remainderColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(176, 176, 176, 0.9)'
-      : 'rgba(0, 0, 0, 0.56)';
+      ? isInputHovered
+        ? 'rgba(218, 226, 238, 0.94)'
+        : 'rgba(176, 176, 176, 0.9)'
+      : isInputHovered
+        ? 'rgba(0, 0, 0, 0.66)'
+        : 'rgba(0, 0, 0, 0.56)';
   const linkTextMetrics = {
     fontSize: '13.5px',
     fontWeight: 400,
@@ -412,9 +422,7 @@ export function GlobalQortalNavBar({
                   handleOpenInput();
                 }
               }}
-              placeholder={t('core:action.search_apps_or_link', {
-                postProcess: 'capitalizeFirstChar',
-              })}
+              placeholder="Search Q-Apps or enter qortal://"
               sx={{
                 color: inputTextColor,
                 flex: 1,

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -117,8 +117,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.72)';
   const inputHoverBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(65, 67, 73, 0.94)'
-      : 'rgba(255, 255, 255, 0.82)';
+      ? 'rgba(69, 82, 108, 0.94)'
+      : 'rgba(205, 223, 244, 0.92)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(68, 71, 77, 0.94)'
@@ -132,9 +132,7 @@ export function GlobalQortalNavBar({
       ? 'rgba(255, 255, 255, 0.24)'
       : 'rgba(0, 0, 0, 0.2)';
   const inputHoverShadow =
-    theme.palette.mode === 'dark'
-      ? `0 0 0 1px rgba(94, 154, 255, 0.3), 0 0 0 3px rgba(94, 154, 255, 0.12)`
-      : `0 0 0 1px rgba(41, 121, 218, 0.28), 0 0 0 3px rgba(41, 121, 218, 0.1)`;
+    'none';
   const inputFocusShadow =
     theme.palette.mode === 'dark'
       ? 'none'

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, ButtonBase, InputBase, useTheme } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
+import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
+import { useAtomValue } from 'jotai';
+import { useTranslation } from 'react-i18next';
+import { extractComponents } from '../Chat/MessageDisplay';
+import { navigationControllerAtom } from '../../atoms/global';
+import {
+  executeEvent,
+  subscribeToEvent,
+  unsubscribeFromEvent,
+} from '../../utils/events';
+import { QORTAL_PROTOCOL } from '../../constants/constants';
+import { APP_NAV_BAR_HEIGHT } from './CustomTitleBar';
+
+type GlobalQortalNavBarProps = {
+  desktopViewMode: string;
+};
+
+type SelectedTab = {
+  tabId: string;
+  name: string;
+  service: string;
+  identifier?: string;
+  path?: string;
+  refreshFunc?: (tabId?: string) => void;
+} | null;
+
+function normalizeQortalInput(value: string) {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return '';
+  if (/^qortal:\/\//i.test(trimmed)) return trimmed;
+  return `${QORTAL_PROTOCOL}${trimmed}`;
+}
+
+export function GlobalQortalNavBar({
+  desktopViewMode,
+}: GlobalQortalNavBarProps) {
+  const theme = useTheme();
+  const navigationController = useAtomValue(navigationControllerAtom);
+  const { t } = useTranslation(['core']);
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>(null);
+  const [inputValue, setInputValue] = useState('');
+  const isInputFocusedRef = useRef(false);
+
+  const setTabsToNav = useCallback((e: CustomEvent) => {
+    const nextSelectedTab = e.detail?.data?.selectedTab;
+    setSelectedTab(nextSelectedTab ? { ...nextSelectedTab } : null);
+  }, []);
+
+  useEffect(() => {
+    subscribeToEvent('setTabsToNav', setTabsToNav);
+
+    return () => {
+      unsubscribeFromEvent('setTabsToNav', setTabsToNav);
+    };
+  }, [setTabsToNav]);
+
+  const currentNavigation = selectedTab?.tabId
+    ? navigationController?.[selectedTab.tabId]
+    : null;
+
+  const currentLink = useMemo(() => {
+    return currentNavigation?.currentLink || '';
+  }, [currentNavigation]);
+
+  useEffect(() => {
+    if (isInputFocusedRef.current) return;
+    if (desktopViewMode === 'apps' && currentLink) {
+      setInputValue(currentLink);
+      return;
+    }
+    if (desktopViewMode !== 'apps') {
+      setInputValue('');
+    }
+  }, [currentLink, desktopViewMode]);
+
+  const handleOpenInput = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    const normalized = normalizeQortalInput(trimmed);
+    const parsedLink = extractComponents(normalized);
+
+    if (parsedLink) {
+      const { service, name, identifier, path } = parsedLink;
+      executeEvent('addTab', { data: { service, name, identifier, path } });
+      executeEvent('open-apps-mode', {});
+      return;
+    }
+
+    executeEvent('openAppsLibrarySearch', {
+      data: {
+        query: trimmed,
+      },
+    });
+    executeEvent('open-apps-mode', {});
+  }, [inputValue]);
+
+  const canGoBack = !!selectedTab?.tabId && !!currentNavigation?.hasBack;
+  const canGoForward = !!selectedTab?.tabId && !!currentNavigation?.hasForward;
+  const canRefresh = !!selectedTab?.tabId && desktopViewMode === 'apps';
+  const chromeBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(39, 40, 44, 0.96)'
+      : 'rgba(206, 209, 216, 0.96)';
+  const inputBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(58, 60, 65, 0.88)'
+      : 'rgba(255, 255, 255, 0.72)';
+  const inputHoverBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(65, 67, 73, 0.94)'
+      : 'rgba(255, 255, 255, 0.82)';
+  const inputFocusBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(70, 73, 79, 0.96)'
+      : 'rgba(255, 255, 255, 0.9)';
+  const hoverBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.16)'
+      : 'rgba(0, 0, 0, 0.14)';
+  const focusBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.24)'
+      : 'rgba(0, 0, 0, 0.2)';
+  const inputHoverShadow =
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgba(255, 255, 255, 0.03), 0 8px 18px rgba(0, 0, 0, 0.14)'
+      : '0 0 0 1px rgba(255, 255, 255, 0.08), 0 8px 18px rgba(120, 127, 140, 0.12)';
+  const inputFocusShadow =
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgba(255, 255, 255, 0.06), 0 10px 24px rgba(0, 0, 0, 0.2)'
+      : '0 0 0 1px rgba(255, 255, 255, 0.12), 0 10px 24px rgba(120, 127, 140, 0.16)';
+  const buttonHoverBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.06)'
+      : 'rgba(0, 0, 0, 0.05)';
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        backdropFilter: 'blur(10px)',
+        backgroundColor: chromeBackground,
+        borderBottom: `1px solid ${theme.palette.border.subtle}`,
+        display: 'flex',
+        height: `${APP_NAV_BAR_HEIGHT}px`,
+        width: '100%',
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: 1.25,
+          height: '100%',
+          maxWidth: '100%',
+          pl: { xs: 1.5, sm: 2, md: 3 },
+          pr: { xs: 1.5, sm: 2, md: 2.5 },
+          width: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            flexShrink: 0,
+            gap: 0.5,
+            pr: 1.25,
+            position: 'relative',
+            '&::after': {
+              backgroundColor: theme.palette.border.subtle,
+              content: '""',
+              height: 20,
+              position: 'absolute',
+              right: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '1px',
+            },
+          }}
+        >
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              executeEvent(`navigateBackApp-${selectedTab.tabId}`, {});
+            }}
+            disabled={!canGoBack}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canGoBack ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowBackIosNewRoundedIcon sx={{ fontSize: 15 }} />
+          </ButtonBase>
+
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              executeEvent(`navigateForwardApp-${selectedTab.tabId}`, {});
+            }}
+            disabled={!canGoForward}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canGoForward ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowForwardIosRoundedIcon sx={{ fontSize: 15 }} />
+          </ButtonBase>
+
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              if (selectedTab?.refreshFunc) {
+                selectedTab.refreshFunc(selectedTab?.tabId);
+                return;
+              }
+              executeEvent('refreshApp', {
+                tabId: selectedTab.tabId,
+              });
+            }}
+            disabled={!canRefresh}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canRefresh ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <RefreshIcon sx={{ fontSize: 18 }} />
+          </ButtonBase>
+        </Box>
+
+        <Box
+          sx={{
+            alignItems: 'center',
+            backgroundColor: inputBackground,
+            border: `1px solid ${theme.palette.border.subtle}`,
+            borderRadius: '12px',
+            display: 'flex',
+            flex: 1,
+            gap: 1,
+            height: 34,
+            minWidth: 0,
+            px: 1.5,
+            boxShadow: 'none',
+            transition:
+              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease, transform 280ms ease',
+            '&:hover': {
+              backgroundColor: inputHoverBackground,
+              borderColor: hoverBorderColor,
+              boxShadow: inputHoverShadow,
+              transform: 'translateY(-1px)',
+            },
+            '&:focus-within': {
+              backgroundColor: inputFocusBackground,
+              borderColor: focusBorderColor,
+              boxShadow: inputFocusShadow,
+              transform: 'translateY(-1px)',
+            },
+          }}
+        >
+          <SearchIcon
+            sx={{
+              color: theme.palette.text.secondary,
+              fontSize: 17,
+            }}
+          />
+          <InputBase
+            value={inputValue}
+            onBlur={() => {
+              isInputFocusedRef.current = false;
+            }}
+            onChange={(e) => setInputValue(e.target.value)}
+            onFocus={() => {
+              isInputFocusedRef.current = true;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleOpenInput();
+              }
+            }}
+            placeholder={t('core:action.search_apps_or_link', {
+              postProcess: 'capitalizeFirstChar',
+            })}
+            sx={{
+              color: theme.palette.text.primary,
+              flex: 1,
+              fontSize: '13.5px',
+              minWidth: 0,
+              '& .MuiInputBase-input': {
+                py: '6px',
+              },
+              '& .MuiInputBase-input::placeholder': {
+                color: theme.palette.text.secondary,
+                opacity: 1,
+              },
+            }}
+          />
+          <ButtonBase
+            onClick={handleOpenInput}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '8px',
+              color: theme.palette.text.secondary,
+              display: 'flex',
+              flexShrink: 0,
+              height: 26,
+              justifyContent: 'center',
+              transition:
+                'background-color 180ms ease, color 180ms ease, transform 220ms ease',
+              width: 26,
+              '&:hover': {
+                backgroundColor: buttonHoverBackground,
+                color: theme.palette.text.primary,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowOutwardIcon sx={{ fontSize: 17 }} />
+          </ButtonBase>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Group/GlobalChatWidget.tsx
+++ b/src/components/Group/GlobalChatWidget.tsx
@@ -46,7 +46,7 @@ import { MiniDirectThread } from '../Chat/MiniDirectThread';
 import { MiniGroupThread } from '../Chat/MiniGroupThread';
 import { useNameSearch } from '../../hooks/useNameSearch';
 import { validateAddress } from '../../utils/validateAddress';
-import { appHeighOffset, appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffset, appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 export type ChatWidgetTab = 'messages' | 'groups';
 
@@ -114,7 +114,7 @@ export function GlobalChatWidget({
     if (typeof window === 'undefined')
       return { x: 0, width: 380, height: 560 };
     const w = window.innerWidth;
-    const h = window.innerHeight - appHeighOffset;
+    const h = window.innerHeight - appChromeOffset;
     const maxW = Math.min(WIDGET_MAX_WIDTH, w - 48);
     const maxH = Math.min(
       WIDGET_MAX_HEIGHT,
@@ -140,7 +140,7 @@ export function GlobalChatWidget({
 
   const [windowSize, setWindowSize] = useState(() =>
     typeof window !== 'undefined'
-      ? { w: window.innerWidth, h: window.innerHeight - appHeighOffset }
+      ? { w: window.innerWidth, h: window.innerHeight - appChromeOffset }
       : { w: 800, h: 600 }
   );
   const [bottomX, setBottomX] = useState(initialBounds.x);
@@ -221,7 +221,7 @@ export function GlobalChatWidget({
 
   useEffect(() => {
     const onResize = () =>
-      setWindowSize({ w: window.innerWidth, h: window.innerHeight - appHeighOffset });
+      setWindowSize({ w: window.innerWidth, h: window.innerHeight - appChromeOffset });
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
@@ -231,7 +231,7 @@ export function GlobalChatWidget({
     if (!storedBounds || hasAppliedStoredRef.current) return;
     hasAppliedStoredRef.current = true;
     const w = window.innerWidth;
-    const h = window.innerHeight - appHeighOffset;
+    const h = window.innerHeight - appChromeOffset;
     const maxW = Math.min(WIDGET_MAX_WIDTH, w - 48);
     const maxH = Math.min(
       WIDGET_MAX_HEIGHT,
@@ -618,7 +618,7 @@ export function GlobalChatWidget({
                   height: widgetHeight,
                   minHeight: WIDGET_MIN_HEIGHT,
                   maxHeight:
-                    `min(800px, calc(100vh - ${appHeighOffsetPx} - 120px))`,
+                    `min(800px, calc(100vh - ${appChromeOffsetPx} - 120px))`,
                   overflow: 'hidden',
                   visibility: 'visible',
                   opacity: 1,

--- a/src/components/Group/Group.styles.ts
+++ b/src/components/Group/Group.styles.ts
@@ -1,7 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/system';
 import { AuthenticatedContainerInnerRight } from '../../styles/App-styles';
-import { appHeighOffset } from '../Desktop/CustomTitleBar';
+import { appChromeOffset } from '../Desktop/CustomTitleBar';
 
 /**
  * Group layout styled components using MUI's styled API.
@@ -55,7 +55,7 @@ export const AdminRowBox = styled(Box)({
 export const ChatContentBox = styled(Box)({
   display: 'flex',
   flexGrow: 1,
-  height: `calc(100vh - ${70 + appHeighOffset}px)`,
+  height: `calc(100vh - ${70 + appChromeOffset}px)`,
   position: 'relative',
 });
 
@@ -72,7 +72,7 @@ export const NotPartGroupDiv = styled('div')({
   alignItems: 'flex-start',
   display: 'flex',
   flexDirection: 'column',
-  height: `calc(100vh - ${70 + appHeighOffset}px)`,
+  height: `calc(100vh - ${70 + appChromeOffset}px)`,
   overflow: 'auto',
   padding: '20px',
   width: '100%',

--- a/src/components/Group/WalletsAppWrapper.tsx
+++ b/src/components/Group/WalletsAppWrapper.tsx
@@ -13,7 +13,7 @@ import { NavBack } from '../../assets/Icons/NavBack.tsx';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 export const WalletsAppWrapper = () => {
   const { t } = useTranslation([
@@ -73,7 +73,7 @@ export const WalletsAppWrapper = () => {
             borderTopRightRadius: '10px',
             bottom: 0,
             boxShadow: 4,
-            height: `calc(100vh - ${appHeighOffsetPx})`,
+            height: `calc(100vh - ${appChromeOffsetPx})`,
             overflow: 'hidden',
             position: 'fixed',
             right: 0,

--- a/src/hooks/useQortalMessageListener.tsx
+++ b/src/hooks/useQortalMessageListener.tsx
@@ -11,10 +11,12 @@ import { mimeToExtensionMap } from '../utils/memeTypes';
 import FileSaver from 'file-saver';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
+  QORTAL_PROTOCOL,
   TIME_HOURS_1_IN_MILLISECONDS,
   TIME_MINUTES_30_IN_MILLISECONDS,
   TIME_SECONDS_30_IN_MILLISECONDS,
 } from '../constants/constants';
+import { buildQortalResourceLink } from '../utils/qortalLink';
 
 export const saveFileInChunks = async (
   blob: Blob,
@@ -535,6 +537,7 @@ export const useQortalMessageListener = (
   isDevMode,
   appName,
   appService,
+  appIdentifier,
   skipAuth
 ) => {
   const [path, setPath] = useState('');
@@ -553,15 +556,38 @@ export const useQortalMessageListener = (
   useEffect(() => {
     if (tabId && !isNaN(history?.currentIndex)) {
       setHasSettingsChangedAtom((prev) => {
+        // Preserve identifier in qortal:// links when present because QDN
+        // targeting depends on it. Links without identifier must still work.
         return {
           ...prev,
           [tabId]: {
             hasBack: history?.currentIndex > 0,
+            hasForward:
+              history?.currentIndex >= 0 &&
+              history?.currentIndex <
+                (history?.customQDNHistoryPaths?.length || 0) - 1,
+            currentLink:
+              appService && appName
+                ? buildQortalResourceLink({
+                    service: appService,
+                    name: appName,
+                    path: path || '',
+                    identifier: appIdentifier,
+                  })
+                : '',
           },
         };
       });
     }
-  }, [history?.currentIndex, tabId]);
+  }, [
+    appIdentifier,
+    appName,
+    appService,
+    history?.currentIndex,
+    history?.customQDNHistoryPaths,
+    path,
+    tabId,
+  ]);
 
   const changeCurrentIndex = useCallback((value) => {
     setHistory((prev) => {

--- a/src/utils/qortalLink/index.ts
+++ b/src/utils/qortalLink/index.ts
@@ -1,3 +1,5 @@
+import { QORTAL_PROTOCOL } from '../../constants/constants';
+
 export function convertQortalLinks(inputHtml: string) {
   // Regular expression to match 'qortal://...' URLs.
   // This will stop at the first whitespace, comma, or HTML tag
@@ -9,4 +11,26 @@ export function convertQortalLinks(inputHtml: string) {
   });
 
   return outputHtml;
+}
+
+type QortalResourceLinkInput = {
+  service?: string;
+  name?: string;
+  path?: string;
+  identifier?: string;
+};
+
+export function buildQortalResourceLink({
+  service,
+  name,
+  path = '',
+  identifier,
+}: QortalResourceLinkInput): string {
+  const encodedName = (name || '').replace(/ /g, '%20');
+  const normalizedPath = path || '';
+  const identifierSuffix = identifier
+    ? `${normalizedPath.includes('?') ? '&' : '?'}identifier=${encodeURIComponent(identifier)}`
+    : '';
+
+  return `${QORTAL_PROTOCOL}${service}/${encodedName}${normalizedPath}${identifierSuffix}`;
 }


### PR DESCRIPTION
Adds a slim, always-visible browser-style Qortal bar beneath the top Hub toolbar.

Supports back, forward, refresh, direct qortal:// navigation, and plain-text app search
Routes plain text into the Apps library for Q-App discovery from Home
Preserves QDN identifier in qortal:// link round-trips to ensure correct Q-App/resource targeting