### PR TITLE
Permission modal UI redesign + local preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,6 +106,7 @@ import {
 } from './components/Desktop/CustomTitleBar';
 import { roundUpToDecimals } from './utils/numberFunctions.ts';
 import { GlobalQortalNavBar } from './components/Desktop/GlobalQortalNavBar.tsx';
+import { QortalPermissionPreview } from './components/App/QortalPermissionPreview.tsx';
 
 // Re-export for consumers that still import from App
 export type { extStates } from './types/app';
@@ -128,6 +129,9 @@ export {
 export { isMainWindow } from './constants/app';
 
 function App() {
+  const permissionPreviewMode =
+    import.meta.env.DEV &&
+    new URLSearchParams(window.location.search).get('permission-preview') === '1';
   const [extState, setExtstate] = useAtom(extStateAtom);
   const [desktopViewMode, setDesktopViewMode] = useState('home');
   const [rawWallet, setRawWallet] = useAtom(rawWalletAtom);
@@ -1337,6 +1341,10 @@ function App() {
           onBackupWallet,
         }
       : null;
+
+  if (permissionPreviewMode) {
+    return <QortalPermissionPreview />;
+  }
 
   return (
     <AppContainer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,7 @@ import {
   CUSTOM_TITLE_BAR_HEIGHT,
 } from './components/Desktop/CustomTitleBar';
 import { roundUpToDecimals } from './utils/numberFunctions.ts';
+import { GlobalQortalNavBar } from './components/Desktop/GlobalQortalNavBar.tsx';
 
 // Re-export for consumers that still import from App
 export type { extStates } from './types/app';
@@ -1348,6 +1349,9 @@ function App() {
       }}
     >
       <CustomTitleBar rightNav={titleBarRightNav} />
+      {extState === 'authenticated' && isMainWindow && (
+        <GlobalQortalNavBar desktopViewMode={desktopViewMode} />
+      )}
 
       <Box
         sx={{

--- a/src/components/App/AuthenticatedShell.tsx
+++ b/src/components/App/AuthenticatedShell.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@mui/material';
 import { Group } from '../Group/Group';
 import { AuthenticatedProfile } from '../Profile';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
 
 /**
  * Authenticated main layout: Group (left) + AuthenticatedProfile (right).
@@ -68,12 +67,29 @@ export function AuthenticatedShell({
 }: AuthenticatedShellProps) {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         display: 'flex',
         flexDirection: 'row',
-        height: `calc(100vh - ${appHeighOffsetPx})`,
+        height: '100%',
+        isolation: 'isolate',
+        position: 'relative',
         width: '100vw',
-      }}
+        '&::before': {
+          background:
+            theme.palette.mode === 'dark'
+              ? 'linear-gradient(to bottom, rgba(16, 18, 22, 0.16), rgba(16, 18, 22, 0.09))'
+              : 'linear-gradient(to bottom, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.08))',
+          content: '""',
+          inset: 0,
+          pointerEvents: 'none',
+          position: 'absolute',
+          zIndex: 0,
+        },
+        '& > *': {
+          position: 'relative',
+          zIndex: 1,
+        },
+      })}
     >
       <Group
         desktopViewMode={desktopViewMode}

--- a/src/components/App/QortalPermissionPreview.tsx
+++ b/src/components/App/QortalPermissionPreview.tsx
@@ -1,0 +1,305 @@
+import { Box, Chip, FormControlLabel, MenuItem, Select, Switch, Typography, alpha, useTheme } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { QortalPermissionCard } from './QortalRequestExtensionDialog';
+import {
+  MODAL_REQUEST_TYPES,
+  type MessageQortalRequestExtension,
+} from './qortalPermissionPresentation';
+
+const PRIORITY_REQUESTS = [
+  'GET_USER_ACCOUNT',
+  'SESSION_PERMISSIONS',
+  'PUBLISH_QDN_RESOURCE',
+  'PUBLISH_MULTIPLE_QDN_RESOURCES',
+  'SEND_COIN',
+  'SIGN_TRANSACTION',
+];
+
+const orderedRequestTypes = [
+  ...PRIORITY_REQUESTS,
+  ...MODAL_REQUEST_TYPES.filter((requestType) => !PRIORITY_REQUESTS.includes(requestType)),
+];
+
+const createPreviewMessage = (
+  requestType: string,
+  includeSource: boolean,
+  includeRemember: boolean,
+  countdownDuration: number
+): MessageQortalRequestExtension => {
+  const baseMessage: MessageQortalRequestExtension = {
+    requestType,
+    countdownDuration,
+    sourceKind: 'Q-App',
+    sourceLabel: includeSource ? 'Q-Tube' : undefined,
+    technicalDetails: [{ rows: [{ label: 'Request type', value: requestType }] }],
+  };
+
+  if (includeRemember) {
+    baseMessage.checkbox1 = {
+      label: 'Always allow this automatically',
+      value: false,
+    };
+  }
+
+  switch (requestType) {
+    case 'GET_USER_ACCOUNT':
+      return {
+        ...baseMessage,
+        summaryBody:
+          'This confirms your Qortal identity for the application. It does not send a payment or publish data.',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Granted account field', value: 'Primary account identity' },
+            ],
+          },
+        ],
+      };
+    case 'SESSION_PERMISSIONS':
+      return {
+        ...baseMessage,
+        confirmCheckbox: true,
+        confirmCheckboxLabel: 'I trust this app and understand these permissions will auto-execute',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Requested permissions', value: 'GET_USER_ACCOUNT, PUBLISH_QDN_RESOURCE, SIGN_TRANSACTION' },
+              { label: 'Scope', value: 'Current session only' },
+            ],
+          },
+        ],
+      };
+    case 'PUBLISH_QDN_RESOURCE':
+      return {
+        ...baseMessage,
+        text2: 'service: DOCUMENT',
+        text3: 'identifier: grp-42-thread-abc123',
+        text4: 'name: q-tube',
+        fee: '0.10000000',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Service', value: 'DOCUMENT' },
+              { label: 'Identifier', value: 'grp-42-thread-abc123' },
+              { label: 'Name', value: 'q-tube' },
+            ],
+          },
+        ],
+      };
+    case 'PUBLISH_MULTIPLE_QDN_RESOURCES':
+      return {
+        ...baseMessage,
+        fee: '0.20000000',
+        html: `
+          <div class="resource-container">
+            <div class="resource-detail"><span>Service:</span> IMAGE</div>
+            <div class="resource-detail"><span>Identifier:</span> grp-q-manager_1_group_42_abcd</div>
+            <div class="resource-detail"><span>Name:</span> q-tube</div>
+          </div>
+          <div class="resource-container">
+            <div class="resource-detail"><span>Service:</span> DOCUMENT_PRIVATE</div>
+            <div class="resource-detail"><span>Identifier:</span> episode-notes-42</div>
+            <div class="resource-detail"><span>Name:</span> q-tube</div>
+          </div>
+        `,
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { value: 'Resource 1' },
+              { label: 'Service', value: 'IMAGE' },
+              { label: 'Identifier', value: 'grp-q-manager_1_group_42_abcd' },
+              { label: 'Name', value: 'q-tube' },
+              { value: 'Resource 2' },
+              { label: 'Service', value: 'DOCUMENT_PRIVATE' },
+              { label: 'Identifier', value: 'episode-notes-42' },
+              { label: 'Name', value: 'q-tube' },
+            ],
+          },
+        ],
+      };
+    case 'SEND_COIN':
+      return {
+        ...baseMessage,
+        text2: 'to: Qabc123receiver',
+        highlightedText: '5 QORT',
+        fee: '0.00100000',
+      };
+    case 'SIGN_TRANSACTION':
+      return {
+        ...baseMessage,
+        summaryBody: 'This app wants your account to sign a transaction. Review the key facts before accepting.',
+        json: {
+          type: 'Payment',
+          recipient: 'Qxyz987destination',
+          amount: '5 QORT',
+        },
+      };
+    case 'ADD_FOREIGN_SERVER':
+      return {
+        ...baseMessage,
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Server host', value: 'api.qortalhub.net' },
+              { label: 'Server port', value: '12391' },
+              { label: 'Protocol', value: 'https' },
+            ],
+          },
+        ],
+      };
+    default:
+      return {
+        ...baseMessage,
+        technicalDetails: [
+          {
+            rows: [{ label: 'Request type', value: requestType }],
+          },
+        ],
+      };
+  }
+};
+
+export function QortalPermissionPreview() {
+  const theme = useTheme();
+  const [requestType, setRequestType] = useState<string>('GET_USER_ACCOUNT');
+  const [includeSource, setIncludeSource] = useState(true);
+  const [includeRemember, setIncludeRemember] = useState(true);
+  const [countdownDuration, setCountdownDuration] = useState(60);
+  const [confirmRequestRead, setConfirmRequestRead] = useState(false);
+  const [previewKey, setPreviewKey] = useState(0);
+
+  const message = useMemo(
+    () => createPreviewMessage(requestType, includeSource, includeRemember, countdownDuration),
+    [requestType, includeSource, includeRemember, countdownDuration]
+  );
+
+  return (
+    <Box
+      sx={{
+        background: theme.palette.mode === 'dark'
+          ? 'linear-gradient(180deg, #17191d 0%, #111317 100%)'
+          : 'linear-gradient(180deg, #f4f6f8 0%, #ecf0f3 100%)',
+        display: 'grid',
+        gap: '24px',
+        gridTemplateColumns: { md: '320px minmax(0, 1fr)' },
+        minHeight: '100vh',
+        padding: '24px',
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: alpha(theme.palette.background.paper, 0.84),
+          border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+          borderRadius: '20px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '18px',
+          padding: '20px',
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Chip label="Dev-only preview" sx={{ alignSelf: 'flex-start' }} />
+          <Typography sx={{ fontSize: '24px', fontWeight: 700 }}>Qortal permission modal preview</Typography>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '14px', lineHeight: 1.5 }}>
+            This page renders the same permission card used by the real modal so common flows and edge cases can be reviewed locally without triggering real requests.
+          </Typography>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '12px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Request type
+          </Typography>
+          <Select
+            value={requestType}
+            onChange={(event) => {
+              setRequestType(event.target.value);
+              setConfirmRequestRead(false);
+              setPreviewKey((value) => value + 1);
+            }}
+            size="small"
+          >
+            {orderedRequestTypes.map((item) => (
+              <MenuItem key={item} value={item}>
+                {item}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={includeSource}
+              onChange={(event) => {
+                setIncludeSource(event.target.checked);
+                setPreviewKey((value) => value + 1);
+              }}
+            />
+          }
+          label="Show source identity"
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={includeRemember}
+              onChange={(event) => {
+                setIncludeRemember(event.target.checked);
+                setPreviewKey((value) => value + 1);
+              }}
+            />
+          }
+          label="Show remember option"
+        />
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '12px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Countdown state
+          </Typography>
+          <Select
+            value={countdownDuration}
+            onChange={(event) => {
+              setCountdownDuration(Number(event.target.value));
+              setPreviewKey((value) => value + 1);
+            }}
+            size="small"
+          >
+            <MenuItem value={60}>60 seconds</MenuItem>
+            <MenuItem value={15}>15 seconds</MenuItem>
+            <MenuItem value={5}>5 seconds</MenuItem>
+          </Select>
+        </Box>
+
+        <Typography sx={{ color: theme.palette.text.secondary, fontSize: '13px', lineHeight: 1.5 }}>
+          Priority flows are listed first: authentication, session permissions, and QDN publishing. The remaining items cover every request type that currently uses the permission modal flow.
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'center',
+          minHeight: '70vh',
+          padding: { xs: 0, md: '12px' },
+        }}
+      >
+        <QortalPermissionCard
+          key={`${requestType}-${includeSource}-${includeRemember}-${countdownDuration}-${previewKey}`}
+          message={message}
+          confirmRequestRead={confirmRequestRead}
+          onConfirmRequestReadChange={setConfirmRequestRead}
+          onCheckbox1Change={() => undefined}
+          onAccept={() => undefined}
+          onCancel={() => undefined}
+          onCountdownComplete={() => undefined}
+          countdownSeconds={countdownDuration}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/App/QortalRequestExtensionDialog.tsx
+++ b/src/components/App/QortalRequestExtensionDialog.tsx
@@ -20,48 +20,12 @@ import { ErrorText } from '../index';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
 import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
-
-export type MessageQortalRequestExtension = {
-  text1?: string;
-  text2?: string;
-  text3?: string;
-  text4?: string;
-  html?: string;
-  highlightedText?: string;
-  json?: any;
-  fee?: string;
-  appFee?: string;
-  foreignFee?: string;
-  checkbox1?: { label?: string; value?: boolean };
-  confirmCheckbox?: boolean;
-  confirmCheckboxLabel?: string;
-};
-
-type DetailRow = {
-  label?: string;
-  value: string;
-};
-
-const parseDetailRow = (value?: string): DetailRow | null => {
-  if (!value?.trim()) return null;
-
-  const trimmed = value.trim();
-  const separatorIndex = trimmed.indexOf(':');
-
-  if (separatorIndex > 0) {
-    return {
-      label: trimmed.slice(0, separatorIndex).trim(),
-      value: trimmed.slice(separatorIndex + 1).trim() || '-',
-    };
-  }
-
-  return { value: trimmed };
-};
-
-const formatRequestTitle = (value?: string) => {
-  if (!value) return 'Permission request';
-  return value.replace(/^Do you give this application permission to\s*/i, '');
-};
+import RadioButtonUncheckedRoundedIcon from '@mui/icons-material/RadioButtonUncheckedRounded';
+import type {
+  MessageQortalRequestExtension,
+  PermissionDetailSection,
+} from './qortalPermissionPresentation';
+import { buildPermissionPresentation } from './qortalPermissionPresentation';
 
 type QortalRequestExtensionDialogProps = {
   open: boolean;
@@ -73,81 +37,167 @@ type QortalRequestExtensionDialogProps = {
   onAccept: () => void;
   onCancel: () => void;
   onCountdownComplete: () => void;
+  countdownSeconds?: number;
 };
 
-export function QortalRequestExtensionDialog({
-  open,
+type PermissionCardProps = {
+  message: MessageQortalRequestExtension;
+  sendPaymentError?: string;
+  confirmRequestRead: boolean;
+  onConfirmRequestReadChange: (checked: boolean) => void;
+  onCheckbox1Change: (checked: boolean) => void;
+  onAccept: () => void;
+  onCancel: () => void;
+  onCountdownComplete: () => void;
+  countdownSeconds?: number;
+};
+
+const renderDetailSection = (
+  section: PermissionDetailSection,
+  index: number,
+  theme: ReturnType<typeof useTheme>
+) => {
+  return (
+    <Box key={`${section.title || 'section'}-${index}`} sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      {section.title && (
+        <Typography
+          sx={{
+            color: theme.palette.text.secondary,
+            fontSize: '12px',
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {section.title}
+        </Typography>
+      )}
+      {section.rows?.length ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {section.rows.map((row, rowIndex) => (
+            <Box
+              key={`${row.label}-${rowIndex}`}
+              sx={{
+                alignItems: row.label ? 'baseline' : 'flex-start',
+                display: 'flex',
+                flexDirection: row.label ? 'row' : 'column',
+                gap: '10px',
+                justifyContent: 'space-between',
+              }}
+            >
+              {row.label ? (
+                <Typography
+                  sx={{
+                    color: theme.palette.text.secondary,
+                    fontSize: '13px',
+                    minWidth: '120px',
+                    textTransform: 'capitalize',
+                  }}
+                >
+                  {row.label}
+                </Typography>
+              ) : null}
+              <TextP
+                sx={{
+                  flex: 1,
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  lineHeight: 1.45,
+                  textAlign: row.label ? 'right' : 'left',
+                }}
+              >
+                {row.value}
+              </TextP>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
+      {section.html ? (
+        <Box
+          sx={{
+            '& *': {
+              color: `${theme.palette.text.primary} !important`,
+              fontFamily: 'Inter, sans-serif !important',
+            },
+            '& p, & li, & span, & div': {
+              lineHeight: '1.45 !important',
+            },
+            '& ul, & ol': {
+              margin: 0,
+              paddingLeft: '18px',
+            },
+          }}
+          dangerouslySetInnerHTML={{ __html: section.html }}
+        />
+      ) : null}
+      {section.json ? (
+        <Box
+          sx={{
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? alpha('#0f141b', 0.72)
+                : alpha('#f4f7fb', 0.92),
+            border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.045 : 0.04)}`,
+            borderRadius: '12px',
+            overflow: 'auto',
+            padding: '10px',
+            '& .json-view': {
+              backgroundColor: 'transparent !important',
+            },
+            '& .string-value, & .number-value, & .boolean-value, & .null-value, & .other-value, & .punctuation, & .data-type-label, & .object-key': {
+              color: `${alpha(theme.palette.text.secondary, theme.palette.mode === 'dark' ? 0.8 : 0.88)} !important`,
+            },
+          }}
+        >
+          <JsonView data={section.json} shouldExpandNode={allExpanded} style={darkStyles} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+export function QortalPermissionCard({
   message,
-  sendPaymentError,
+  sendPaymentError = '',
   confirmRequestRead,
   onConfirmRequestReadChange,
   onCheckbox1Change,
   onAccept,
   onCancel,
   onCountdownComplete,
-}: QortalRequestExtensionDialogProps) {
+  countdownSeconds,
+}: PermissionCardProps) {
   const theme = useTheme();
   const { t } = useTranslation(['core']);
-  const typedMessage = (message || {}) as MessageQortalRequestExtension;
-  const baseDetailRows = [typedMessage.text2, typedMessage.text3, typedMessage.text4]
-    .map(parseDetailRow)
-    .filter(Boolean) as DetailRow[];
-  const summaryDetailRows = typedMessage.highlightedText
-    ? baseDetailRows.slice(0, 1)
-    : baseDetailRows.slice(0, 2);
-  const accordionDetailRows = baseDetailRows.slice(summaryDetailRows.length);
-  const feeRows = [
-    typedMessage.fee
-      ? { label: 'Network fee', value: `${typedMessage.fee} QORT` }
-      : null,
-    typedMessage.appFee
-      ? {
-          label: t('core:message.generic.fee_qort', {
-            fee: typedMessage.appFee,
-            postProcess: 'capitalizeFirstChar',
-          }).split(':')[0],
-          value: `${typedMessage.appFee} QORT`,
-        }
-      : null,
-    typedMessage.foreignFee
-      ? {
-          label: t('core:message.generic.foreign_fee', {
-            fee: typedMessage.foreignFee,
-            postProcess: 'capitalizeFirstChar',
-          }).split(':')[0],
-          value: typedMessage.foreignFee,
-        }
-      : null,
-  ].filter(Boolean) as DetailRow[];
-  const showHtmlInSummary =
-    !!typedMessage.html &&
-    !typedMessage.highlightedText &&
-    summaryDetailRows.length === 0;
-  const hasDetailsAccordion =
-    accordionDetailRows.length > 0 ||
-    (!!typedMessage.html && !showHtmlInSummary) ||
-    !!typedMessage.json;
-  const canAccept = !typedMessage.confirmCheckbox || confirmRequestRead;
-
-  if (!open) return null;
+  const presentation = buildPermissionPresentation(message, t);
+  const canAccept = !message.confirmCheckbox || confirmRequestRead;
+  const duration = countdownSeconds ?? message.countdownDuration ?? 60;
+  const hasDetailsAccordion = presentation.detailsSections.length > 0;
+  const requiresAcknowledgement = !!message.confirmCheckbox;
+  const acknowledgementMessage = requiresAcknowledgement
+    ? 'Please confirm before continuing.'
+    : '';
 
   return (
-    <Dialog
-      open={open}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-      PaperProps={{
-        sx: {
-          backgroundColor: alpha(theme.palette.background.paper, 0.98),
-          backgroundImage: 'none',
-          border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-          borderRadius: '22px',
-          boxShadow: '0px 22px 64px rgba(0, 0, 0, 0.42)',
-          color: theme.palette.text.primary,
-          maxWidth: '560px',
-          overflow: 'hidden',
-          width: 'min(560px, calc(100vw - 32px))',
-        },
+    <Box
+      sx={{
+        backgroundColor:
+          theme.palette.mode === 'dark'
+            ? alpha('#0d1117', 0.985)
+            : alpha('#ffffff', 0.985),
+        backgroundImage: 'none',
+        border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.07 : 0.06)}`,
+        borderRadius: '24px',
+        boxShadow:
+          theme.palette.mode === 'dark'
+            ? '0px 28px 72px rgba(0, 0, 0, 0.52)'
+            : '0px 18px 52px rgba(16, 24, 40, 0.14)',
+        color: theme.palette.text.primary,
+        display: 'flex',
+        flexDirection: 'column',
+        maxWidth: '560px',
+        overflow: 'hidden',
+        width: 'min(560px, calc(100vw - 32px))',
       }}
     >
       <Box
@@ -166,13 +216,15 @@ export function QortalRequestExtensionDialog({
             gap: '16px',
             justifyContent: 'space-between',
             width: '100%',
+            paddingBottom: '18px',
+            borderBottom: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px', minWidth: 0 }}>
             <Box
               sx={{
                 alignItems: 'center',
-                color: theme.palette.text.secondary,
+                color: alpha(theme.palette.text.secondary, 0.92),
                 display: 'flex',
                 gap: '8px',
               }}
@@ -186,7 +238,9 @@ export function QortalRequestExtensionDialog({
                   textTransform: 'uppercase',
                 }}
               >
-                Permission request
+                {presentation.sourceLabel
+                  ? `${presentation.sourceKind}: ${presentation.sourceLabel}`
+                  : `${presentation.sourceKind} request`}
               </Typography>
             </Box>
             <TextP
@@ -197,26 +251,27 @@ export function QortalRequestExtensionDialog({
                 lineHeight: 1.12,
               }}
             >
-              {formatRequestTitle(typedMessage.text1)}
+              {presentation.title}
             </TextP>
             <Typography
               sx={{
-                color: theme.palette.text.secondary,
+                color: alpha(theme.palette.text.secondary, 0.92),
                 fontSize: '14px',
                 lineHeight: 1.5,
                 maxWidth: '440px',
               }}
             >
-              Review what this application is asking for before you accept. Important
-              decision details stay visible here, and extra request metadata is kept in
-              the details section when available.
+              {presentation.body}
             </Typography>
           </Box>
           <Box
             sx={{
               alignItems: 'center',
-              backgroundColor: alpha(theme.palette.background.default, 0.8),
-              border: `1px solid ${alpha(theme.palette.common.white, 0.1)}`,
+              backgroundColor:
+                theme.palette.mode === 'dark'
+                  ? alpha('#0e141c', 0.95)
+                  : alpha('#f2f5f8', 0.98),
+              border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.14)}`,
               borderRadius: '999px',
               display: 'flex',
               justifyContent: 'center',
@@ -226,9 +281,9 @@ export function QortalRequestExtensionDialog({
           >
             <CountdownCircleTimer
               isPlaying
-              duration={60}
+              duration={duration}
               colors={['#2D7FF9', '#E8A13A', '#C45151', '#C45151']}
-              colorsTime={[25, 12, 5, 0]}
+              colorsTime={[Math.max(duration * 0.4, 10), Math.max(duration * 0.2, 5), 3, 0]}
               onComplete={onCountdownComplete}
               size={42}
               strokeWidth={4}
@@ -240,22 +295,20 @@ export function QortalRequestExtensionDialog({
             </CountdownCircleTimer>
           </Box>
         </Box>
+
         <Spacer height="22px" />
+
         <Box
           sx={{
-            backgroundColor: alpha(theme.palette.background.default, 0.56),
-            border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-            borderRadius: '18px',
             display: 'flex',
             flexDirection: 'column',
-            gap: '16px',
-            padding: '18px',
+            gap: '14px',
             width: '100%',
           }}
         >
           <Typography
             sx={{
-              color: theme.palette.text.secondary,
+              color: alpha(theme.palette.text.secondary, 0.82),
               fontSize: '12px',
               fontWeight: 700,
               letterSpacing: '0.08em',
@@ -264,123 +317,92 @@ export function QortalRequestExtensionDialog({
           >
             What you are approving
           </Typography>
-          {typedMessage.highlightedText && (
-            <Box
-              sx={{
-                backgroundColor: alpha(theme.palette.primary.main, 0.1),
-                border: `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
-                borderRadius: '14px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '6px',
-                padding: '14px',
-              }}
-            >
-              <Typography
-                sx={{
-                  color: theme.palette.text.secondary,
-                  fontSize: '12px',
-                  fontWeight: 700,
-                  letterSpacing: '0.05em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                Requested value
-              </Typography>
-              <TextP sx={{ fontSize: '16px', fontWeight: 700, lineHeight: 1.35 }}>
-                {typedMessage.highlightedText}
-              </TextP>
-            </Box>
-          )}
-          {summaryDetailRows.length > 0 && (
+
+          {presentation.summaryItems.length ? (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              {summaryDetailRows.map((row, index) => (
-                <Box
-                  key={`${row.label || row.value}-${index}`}
-                  sx={{
-                    alignItems: row.label ? 'baseline' : 'flex-start',
-                    display: 'flex',
-                    flexDirection: row.label ? 'row' : 'column',
-                    gap: '8px',
-                    justifyContent: 'space-between',
-                  }}
-                >
-                  {row.label ? (
-                    <>
-                      <Typography
-                        sx={{
-                          color: theme.palette.text.secondary,
-                          fontSize: '13px',
-                          minWidth: '110px',
-                          textTransform: 'capitalize',
-                        }}
-                      >
-                        {row.label}
-                      </Typography>
-                      <TextP
-                        sx={{
-                          flex: 1,
-                          fontSize: '15px',
-                          fontWeight: 600,
-                          lineHeight: 1.35,
-                          textAlign: 'right',
-                        }}
-                      >
-                        {row.value}
-                      </TextP>
-                    </>
-                  ) : (
+              {presentation.summaryItems.map((row, index) => (
+                row.label ? (
+                  <Box
+                    key={`${row.label}-${index}`}
+                    sx={{
+                      alignItems: 'baseline',
+                      display: 'flex',
+                      gap: '10px',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        color: alpha(theme.palette.text.secondary, 0.92),
+                        fontSize: '13px',
+                        minWidth: '110px',
+                        textTransform: 'capitalize',
+                      }}
+                    >
+                      {row.label}
+                    </Typography>
                     <TextP
                       sx={{
+                        flex: 1,
                         fontSize: '15px',
                         fontWeight: 600,
-                        lineHeight: 1.45,
+                        lineHeight: 1.42,
+                        textAlign: 'right',
                       }}
                     >
                       {row.value}
                     </TextP>
-                  )}
-                </Box>
+                  </Box>
+                ) : (
+                  <Box
+                    key={`bullet-${index}`}
+                    sx={{
+                      alignItems: 'flex-start',
+                      display: 'flex',
+                      gap: '10px',
+                    }}
+                  >
+                    <RadioButtonUncheckedRoundedIcon
+                      sx={{
+                        color: alpha(theme.palette.primary.main, 0.7),
+                        fontSize: '12px',
+                        marginTop: '5px',
+                      }}
+                    />
+                    <Typography
+                      sx={{
+                        color: theme.palette.text.primary,
+                        fontSize: '15px',
+                        fontWeight: 500,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      {row.value}
+                    </Typography>
+                  </Box>
+                )
               ))}
             </Box>
-          )}
-          {showHtmlInSummary && (
+          ) : null}
+
+          {presentation.feeItems.length ? (
             <Box
               sx={{
-                '& *': {
-                  color: `${theme.palette.text.primary} !important`,
-                  fontFamily: 'Inter, sans-serif !important',
-                },
-                '& p, & li, & span': {
-                  color: `${theme.palette.text.secondary} !important`,
-                  lineHeight: '1.45 !important',
-                },
-                '& ul, & ol': {
-                  margin: 0,
-                  paddingLeft: '18px',
-                },
-              }}
-              dangerouslySetInnerHTML={{ __html: typedMessage.html as string }}
-            />
-          )}
-          {feeRows.length > 0 && (
-            <Box
-              sx={{
-                borderTop: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                borderTop: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
                 display: 'flex',
                 flexDirection: 'column',
                 gap: '10px',
                 paddingTop: '16px',
               }}
             >
-              {feeRows.map((row, index) => (
+              {presentation.feeItems.map((row, index) => (
                 <Box
                   key={`${row.label}-${index}`}
                   sx={{
                     alignItems: 'center',
                     display: 'flex',
-                    justifyContent: 'space-between',
                     gap: '12px',
+                    justifyContent: 'space-between',
                   }}
                 >
                   <Typography sx={{ color: theme.palette.text.secondary, fontSize: '13px' }}>
@@ -390,32 +412,39 @@ export function QortalRequestExtensionDialog({
                 </Box>
               ))}
             </Box>
-          )}
+          ) : null}
         </Box>
-        {(typedMessage.checkbox1 || typedMessage.confirmCheckbox) && (
+
+        {(message.checkbox1 || message.confirmCheckbox) ? (
           <>
             <Spacer height="16px" />
             <Box
               sx={{
-                backgroundColor: alpha(theme.palette.background.default, 0.38),
-                border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#131922', 0.82)
+                    : alpha('#f5f8fb', 0.92),
+                border: `1px solid ${alpha(
+                  requiresAcknowledgement ? theme.palette.warning.main : theme.palette.common.white,
+                  requiresAcknowledgement ? 0.22 : theme.palette.mode === 'dark' ? 0.06 : 0.05
+                )}`,
                 borderRadius: '16px',
                 display: 'flex',
                 flexDirection: 'column',
-                gap: '4px',
-                padding: '10px 14px',
+                gap: '8px',
+                padding: '12px 14px',
                 width: '100%',
               }}
             >
-              {typedMessage.checkbox1 && (
+              {message.checkbox1 ? (
                 <FormControlLabel
                   control={
                     <Checkbox
-                      onChange={(e) => onCheckbox1Change(e.target.checked)}
+                      onChange={(event) => onCheckbox1Change(event.target.checked)}
                       edge="start"
                       tabIndex={-1}
                       disableRipple
-                      defaultChecked={typedMessage.checkbox1?.value}
+                      defaultChecked={message.checkbox1?.value}
                       sx={{
                         '&.Mui-checked': {
                           color: theme.palette.text.secondary,
@@ -428,17 +457,18 @@ export function QortalRequestExtensionDialog({
                   }
                   label={
                     <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px' }}>
-                      {typedMessage.checkbox1?.label}
+                      {message.checkbox1?.label}
                     </Typography>
                   }
                   sx={{ margin: 0 }}
                 />
-              )}
-              {typedMessage.confirmCheckbox && (
+              ) : null}
+
+              {message.confirmCheckbox ? (
                 <FormControlLabel
                   control={
                     <Checkbox
-                      onChange={(e) => onConfirmRequestReadChange(e.target.checked)}
+                      onChange={(event) => onConfirmRequestReadChange(event.target.checked)}
                       checked={confirmRequestRead}
                       edge="start"
                       tabIndex={-1}
@@ -454,9 +484,9 @@ export function QortalRequestExtensionDialog({
                     />
                   }
                   label={
-                    <Box sx={{ alignItems: 'center', display: 'flex', gap: '8px' }}>
-                      <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px' }}>
-                        {typedMessage.confirmCheckboxLabel ||
+                    <Box sx={{ alignItems: 'center', display: 'flex', gap: '8px', paddingRight: '8px' }}>
+                      <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px', lineHeight: 1.45 }}>
+                        {message.confirmCheckboxLabel ||
                           t('core:message.success.request_read', {
                             postProcess: 'capitalizeFirstChar',
                           })}
@@ -466,19 +496,35 @@ export function QortalRequestExtensionDialog({
                   }
                   sx={{ margin: 0 }}
                 />
-              )}
+              ) : null}
             </Box>
+            {requiresAcknowledgement && !canAccept ? (
+              <Typography
+                sx={{
+                  color: alpha(theme.palette.warning.light, 0.92),
+                  fontSize: '13px',
+                  lineHeight: 1.45,
+                  marginTop: '8px',
+                }}
+              >
+                {acknowledgementMessage}
+              </Typography>
+            ) : null}
           </>
-        )}
-        {hasDetailsAccordion && (
+        ) : null}
+
+        {hasDetailsAccordion ? (
           <>
             <Spacer height="16px" />
             <Accordion
               sx={{
-                backgroundColor: alpha(theme.palette.background.default, 0.28),
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#121821', 0.72)
+                    : alpha('#f4f7fb', 0.96),
                 backgroundImage: 'none',
-                border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-                borderRadius: '16px !important',
+                border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.06 : 0.05)}`,
+                borderRadius: '18px !important',
                 boxShadow: 'none',
                 color: theme.palette.text.primary,
                 width: '100%',
@@ -504,86 +550,22 @@ export function QortalRequestExtensionDialog({
                     fontWeight: 700,
                   }}
                 >
-                  Technical details
+                  More details
                 </Typography>
               </AccordionSummary>
               <AccordionDetails sx={{ padding: '0 18px 18px' }}>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
-                  {accordionDetailRows.map((row, index) => (
-                    <Box
-                      key={`${row.label || row.value}-${index}`}
-                      sx={{
-                        borderBottom:
-                          index !== accordionDetailRows.length - 1 ||
-                          typedMessage.html ||
-                          typedMessage.json
-                            ? `1px solid ${alpha(theme.palette.common.white, 0.08)}`
-                            : 'none',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '4px',
-                        paddingBottom: '12px',
-                      }}
-                    >
-                      {row.label && (
-                        <Typography
-                          sx={{
-                            color: theme.palette.text.secondary,
-                            fontSize: '12px',
-                            fontWeight: 700,
-                            letterSpacing: '0.05em',
-                            textTransform: 'uppercase',
-                          }}
-                        >
-                          {row.label}
-                        </Typography>
-                      )}
-                      <TextP sx={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.45 }}>
-                        {row.value}
-                      </TextP>
-                    </Box>
-                  ))}
-                  {!!typedMessage.html && !showHtmlInSummary && (
-                    <Box
-                      sx={{
-                        '& *': {
-                          color: `${theme.palette.text.primary} !important`,
-                          fontFamily: 'Inter, sans-serif !important',
-                        },
-                        '& p, & li, & span': {
-                          color: `${theme.palette.text.secondary} !important`,
-                          lineHeight: '1.45 !important',
-                        },
-                        '& ul, & ol': {
-                          margin: 0,
-                          paddingLeft: '18px',
-                        },
-                      }}
-                      dangerouslySetInnerHTML={{ __html: typedMessage.html as string }}
-                    />
-                  )}
-                  {typedMessage.json && (
-                    <Box
-                      sx={{
-                        border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-                        borderRadius: '12px',
-                        overflow: 'auto',
-                        padding: '10px',
-                      }}
-                    >
-                      <JsonView
-                        data={typedMessage.json}
-                        shouldExpandNode={allExpanded}
-                        style={darkStyles}
-                      />
-                    </Box>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
+                  {presentation.detailsSections.map((section, index) =>
+                    renderDetailSection(section, index, theme)
                   )}
                 </Box>
               </AccordionDetails>
             </Accordion>
           </>
-        )}
+        ) : null}
+
         <Spacer height="22px" />
+
         <Box
           sx={{
             alignItems: 'center',
@@ -594,25 +576,68 @@ export function QortalRequestExtensionDialog({
           }}
         >
           <CustomButtonAccept
-            customColor="black"
-            customBgColor={alpha(theme.palette.other.danger, 0.9)}
+            customColor={theme.palette.text.primary}
+            customBgColor={
+              theme.palette.mode === 'dark'
+                ? alpha('#171d27', 0.96)
+                : alpha('#eef3f8', 0.98)
+            }
             sx={{
-              minWidth: '118px',
-              opacity: 0.92,
+              minWidth: '122px',
+              border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0px 10px 24px rgba(0,0,0,0.24)'
+                  : '0px 8px 18px rgba(15,23,42,0.08)',
+              transition:
+                'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease',
+              '&:hover': {
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#21171c', 0.98)
+                    : alpha('#f8eef0', 0.98),
+                borderColor: alpha(theme.palette.error.main, 0.2),
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0px 14px 28px rgba(116, 34, 55, 0.2)'
+                    : '0px 12px 22px rgba(185, 28, 28, 0.08)',
+                transform: 'translateY(-1px)',
+              },
             }}
             onClick={onCancel}
           >
             {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
           </CustomButtonAccept>
           <CustomButtonAccept
-            customColor="black"
-            customBgColor={theme.palette.other.positive}
+            customColor="#06111c"
+            customBgColor={
+              theme.palette.mode === 'dark'
+                ? '#76aef4'
+                : '#6da5eb'
+            }
             sx={{
-              minWidth: '118px',
+              minWidth: '122px',
               opacity: canAccept ? 1 : 0.35,
               cursor: canAccept ? 'pointer' : 'default',
+              border: `1px solid ${alpha('#b6d3ff', 0.26)}`,
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0px 10px 24px rgba(58, 112, 188, 0.26)'
+                  : '0px 8px 18px rgba(67, 112, 181, 0.16)',
+              transition:
+                'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease, opacity 180ms ease',
               '&:hover': {
                 opacity: canAccept ? 1 : 0.35,
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? '#86baf8'
+                    : '#78aff0',
+                borderColor: alpha('#d2e4ff', 0.36),
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0px 14px 30px rgba(76, 133, 214, 0.28)'
+                    : '0px 12px 24px rgba(77, 124, 212, 0.18)',
+                transform: canAccept ? 'translateY(-1px)' : 'none',
               },
             }}
             onClick={onAccept}
@@ -620,8 +645,56 @@ export function QortalRequestExtensionDialog({
             {t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
           </CustomButtonAccept>
         </Box>
-        <ErrorText sx={{ marginTop: '12px', width: '100%' }}>{sendPaymentError}</ErrorText>
+
+        {sendPaymentError ? (
+          <ErrorText sx={{ marginTop: '12px', width: '100%' }}>{sendPaymentError}</ErrorText>
+        ) : null}
       </Box>
+    </Box>
+  );
+}
+
+export function QortalRequestExtensionDialog({
+  open,
+  message,
+  sendPaymentError,
+  confirmRequestRead,
+  onConfirmRequestReadChange,
+  onCheckbox1Change,
+  onAccept,
+  onCancel,
+  onCountdownComplete,
+  countdownSeconds,
+}: QortalRequestExtensionDialogProps) {
+  if (!open) return null;
+
+  return (
+    <Dialog
+      open={open}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      PaperProps={{
+        sx: {
+          backgroundColor: 'transparent',
+          backgroundImage: 'none',
+          boxShadow: 'none',
+          overflow: 'visible',
+        },
+      }}
+    >
+      <QortalPermissionCard
+        message={(message || {}) as MessageQortalRequestExtension}
+        sendPaymentError={sendPaymentError}
+        confirmRequestRead={confirmRequestRead}
+        onConfirmRequestReadChange={onConfirmRequestReadChange}
+        onCheckbox1Change={onCheckbox1Change}
+        onAccept={onAccept}
+        onCancel={onCancel}
+        onCountdownComplete={onCountdownComplete}
+        countdownSeconds={countdownSeconds}
+      />
     </Dialog>
   );
 }
+
+export type { MessageQortalRequestExtension } from './qortalPermissionPresentation';

--- a/src/components/App/QortalRequestExtensionDialog.tsx
+++ b/src/components/App/QortalRequestExtensionDialog.tsx
@@ -1,4 +1,15 @@
-import { Box, Checkbox, Dialog, FormControlLabel, Typography, useTheme } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Checkbox,
+  Dialog,
+  FormControlLabel,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { JsonView, allExpanded, darkStyles } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
@@ -7,6 +18,8 @@ import { Spacer } from '../../common/Spacer';
 import { CustomButtonAccept, TextP } from '../../styles/App-styles.ts';
 import { ErrorText } from '../index';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 
 export type MessageQortalRequestExtension = {
   text1?: string;
@@ -22,6 +35,32 @@ export type MessageQortalRequestExtension = {
   checkbox1?: { label?: string; value?: boolean };
   confirmCheckbox?: boolean;
   confirmCheckboxLabel?: string;
+};
+
+type DetailRow = {
+  label?: string;
+  value: string;
+};
+
+const parseDetailRow = (value?: string): DetailRow | null => {
+  if (!value?.trim()) return null;
+
+  const trimmed = value.trim();
+  const separatorIndex = trimmed.indexOf(':');
+
+  if (separatorIndex > 0) {
+    return {
+      label: trimmed.slice(0, separatorIndex).trim(),
+      value: trimmed.slice(separatorIndex + 1).trim() || '-',
+    };
+  }
+
+  return { value: trimmed };
+};
+
+const formatRequestTitle = (value?: string) => {
+  if (!value) return 'Permission request';
+  return value.replace(/^Do you give this application permission to\s*/i, '');
 };
 
 type QortalRequestExtensionDialogProps = {
@@ -49,6 +88,46 @@ export function QortalRequestExtensionDialog({
 }: QortalRequestExtensionDialogProps) {
   const theme = useTheme();
   const { t } = useTranslation(['core']);
+  const typedMessage = (message || {}) as MessageQortalRequestExtension;
+  const baseDetailRows = [typedMessage.text2, typedMessage.text3, typedMessage.text4]
+    .map(parseDetailRow)
+    .filter(Boolean) as DetailRow[];
+  const summaryDetailRows = typedMessage.highlightedText
+    ? baseDetailRows.slice(0, 1)
+    : baseDetailRows.slice(0, 2);
+  const accordionDetailRows = baseDetailRows.slice(summaryDetailRows.length);
+  const feeRows = [
+    typedMessage.fee
+      ? { label: 'Network fee', value: `${typedMessage.fee} QORT` }
+      : null,
+    typedMessage.appFee
+      ? {
+          label: t('core:message.generic.fee_qort', {
+            fee: typedMessage.appFee,
+            postProcess: 'capitalizeFirstChar',
+          }).split(':')[0],
+          value: `${typedMessage.appFee} QORT`,
+        }
+      : null,
+    typedMessage.foreignFee
+      ? {
+          label: t('core:message.generic.foreign_fee', {
+            fee: typedMessage.foreignFee,
+            postProcess: 'capitalizeFirstChar',
+          }).split(':')[0],
+          value: typedMessage.foreignFee,
+        }
+      : null,
+  ].filter(Boolean) as DetailRow[];
+  const showHtmlInSummary =
+    !!typedMessage.html &&
+    !typedMessage.highlightedText &&
+    summaryDetailRows.length === 0;
+  const hasDetailsAccordion =
+    accordionDetailRows.length > 0 ||
+    (!!typedMessage.html && !showHtmlInSummary) ||
+    !!typedMessage.json;
+  const canAccept = !typedMessage.confirmCheckbox || confirmRequestRead;
 
   if (!open) return null;
 
@@ -57,299 +136,491 @@ export function QortalRequestExtensionDialog({
       open={open}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
+      PaperProps={{
+        sx: {
+          backgroundColor: alpha(theme.palette.background.paper, 0.98),
+          backgroundImage: 'none',
+          border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+          borderRadius: '22px',
+          boxShadow: '0px 22px 64px rgba(0, 0, 0, 0.42)',
+          color: theme.palette.text.primary,
+          maxWidth: '560px',
+          overflow: 'hidden',
+          width: 'min(560px, calc(100vw - 32px))',
+        },
+      }}
     >
-      <CountdownCircleTimer
-        isPlaying
-        duration={60}
-        colors={['#004777', '#F7B801', '#A30000', '#A30000']}
-        colorsTime={[7, 5, 2, 0]}
-        onComplete={onCountdownComplete}
-        size={50}
-        strokeWidth={5}
-      >
-        {({ remainingTime }) => <TextP>{remainingTime}</TextP>}
-      </CountdownCircleTimer>
       <Box
         sx={{
-          alignItems: 'center',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'flex-start',
           maxHeight: '90vh',
           overflow: 'auto',
-          padding: '20px',
+          padding: '26px',
         }}
       >
         <Box
           sx={{
+            alignItems: 'flex-start',
             display: 'flex',
-            justifyContent: 'center',
+            gap: '16px',
+            justifyContent: 'space-between',
             width: '100%',
           }}
         >
-          <TextP
-            sx={{
-              lineHeight: 1.2,
-              maxWidth: '90%',
-              textAlign: 'center',
-              fontSize: '16px',
-              marginBottom: '10px',
-            }}
-          >
-            {message?.text1}
-          </TextP>
-        </Box>
-        {message?.text2 && (
-          <>
-            <Spacer height="10px" />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px', minWidth: 0 }}>
             <Box
               sx={{
+                alignItems: 'center',
+                color: theme.palette.text.secondary,
                 display: 'flex',
-                justifyContent: 'flex-start',
-                width: '90%',
+                gap: '8px',
               }}
             >
-              <TextP
+              <ShieldOutlinedIcon sx={{ fontSize: '18px' }} />
+              <Typography
                 sx={{
-                  lineHeight: 1.2,
-                  fontSize: '16px',
-                  fontWeight: 'normal',
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
                 }}
               >
-                {message.text2}
-              </TextP>
+                Permission request
+              </Typography>
             </Box>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.text3 && (
-          <>
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'flex-start',
-                width: '90%',
-              }}
-            >
-              <TextP
-                sx={{
-                  lineHeight: 1.2,
-                  fontSize: '16px',
-                  fontWeight: 'normal',
-                }}
-              >
-                {message.text3}
-              </TextP>
-            </Box>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.text4 && (
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'flex-start',
-              width: '90%',
-            }}
-          >
             <TextP
               sx={{
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
+                fontSize: '29px',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.12,
               }}
             >
-              {message.text4}
+              {formatRequestTitle(typedMessage.text1)}
             </TextP>
-          </Box>
-        )}
-        {message?.html && (
-          <>
-            <Spacer height="15px" />
-            <div dangerouslySetInnerHTML={{ __html: message.html }} />
-          </>
-        )}
-        <Spacer height="15px" />
-        <TextP
-          sx={{
-            textAlign: 'center',
-            lineHeight: 1.2,
-            fontSize: '16px',
-            fontWeight: 700,
-            maxWidth: '90%',
-          }}
-        >
-          {message?.highlightedText}
-        </TextP>
-        {message?.json && (
-          <>
-            <Spacer height="15px" />
-            <JsonView
-              data={message.json}
-              shouldExpandNode={allExpanded}
-              style={darkStyles}
-            />
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.fee && (
-          <>
-            <Spacer height="15px" />
-            <TextP
+            <Typography
               sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
+                color: theme.palette.text.secondary,
+                fontSize: '14px',
+                lineHeight: 1.5,
+                maxWidth: '440px',
               }}
             >
-              {'Fee: '}
-              {message.fee}
-              {' QORT'}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.appFee && (
-          <>
-            <TextP
-              sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
-              }}
-            >
-              {t('core:message.generic.fee_qort', {
-                fee: message.appFee,
-                postProcess: 'capitalizeFirstChar',
-              })}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.foreignFee && (
-          <>
-            <Spacer height="15px" />
-            <TextP
-              sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
-              }}
-            >
-              {t('core:message.generic.foreign_fee', {
-                fee: message.foreignFee,
-                postProcess: 'capitalizeFirstChar',
-              })}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.checkbox1 && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '90%',
-              marginTop: '20px',
-            }}
-          >
-            <Checkbox
-              onChange={(e) => onCheckbox1Change(e.target.checked)}
-              edge="start"
-              tabIndex={-1}
-              disableRipple
-              defaultChecked={message.checkbox1?.value}
-              sx={{
-                '&.Mui-checked': {
-                  color: theme.palette.text.secondary,
-                },
-                '& .MuiSvgIcon-root': {
-                  color: theme.palette.text.secondary,
-                },
-              }}
-            />
-            <Typography sx={{ fontSize: '14px' }}>
-              {message.checkbox1?.label}
+              Review what this application is asking for before you accept. Important
+              decision details stay visible here, and extra request metadata is kept in
+              the details section when available.
             </Typography>
           </Box>
-        )}
-        {message?.confirmCheckbox && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                onChange={(e) => onConfirmRequestReadChange(e.target.checked)}
-                checked={confirmRequestRead}
-                edge="start"
-                tabIndex={-1}
-                disableRipple
+          <Box
+            sx={{
+              alignItems: 'center',
+              backgroundColor: alpha(theme.palette.background.default, 0.8),
+              border: `1px solid ${alpha(theme.palette.common.white, 0.1)}`,
+              borderRadius: '999px',
+              display: 'flex',
+              justifyContent: 'center',
+              minWidth: '74px',
+              padding: '6px 10px',
+            }}
+          >
+            <CountdownCircleTimer
+              isPlaying
+              duration={60}
+              colors={['#2D7FF9', '#E8A13A', '#C45151', '#C45151']}
+              colorsTime={[25, 12, 5, 0]}
+              onComplete={onCountdownComplete}
+              size={42}
+              strokeWidth={4}
+              trailColor={alpha(theme.palette.common.white, 0.12)}
+            >
+              {({ remainingTime }) => (
+                <TextP sx={{ fontSize: '13px', fontWeight: 700 }}>{remainingTime}</TextP>
+              )}
+            </CountdownCircleTimer>
+          </Box>
+        </Box>
+        <Spacer height="22px" />
+        <Box
+          sx={{
+            backgroundColor: alpha(theme.palette.background.default, 0.56),
+            border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+            borderRadius: '18px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+            padding: '18px',
+            width: '100%',
+          }}
+        >
+          <Typography
+            sx={{
+              color: theme.palette.text.secondary,
+              fontSize: '12px',
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            What you are approving
+          </Typography>
+          {typedMessage.highlightedText && (
+            <Box
+              sx={{
+                backgroundColor: alpha(theme.palette.primary.main, 0.1),
+                border: `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+                borderRadius: '14px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '6px',
+                padding: '14px',
+              }}
+            >
+              <Typography
                 sx={{
-                  '&.Mui-checked': {
-                    color: theme.palette.text.secondary,
-                  },
-                  '& .MuiSvgIcon-root': {
-                    color: theme.palette.text.secondary,
+                  color: theme.palette.text.secondary,
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  letterSpacing: '0.05em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Requested value
+              </Typography>
+              <TextP sx={{ fontSize: '16px', fontWeight: 700, lineHeight: 1.35 }}>
+                {typedMessage.highlightedText}
+              </TextP>
+            </Box>
+          )}
+          {summaryDetailRows.length > 0 && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {summaryDetailRows.map((row, index) => (
+                <Box
+                  key={`${row.label || row.value}-${index}`}
+                  sx={{
+                    alignItems: row.label ? 'baseline' : 'flex-start',
+                    display: 'flex',
+                    flexDirection: row.label ? 'row' : 'column',
+                    gap: '8px',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  {row.label ? (
+                    <>
+                      <Typography
+                        sx={{
+                          color: theme.palette.text.secondary,
+                          fontSize: '13px',
+                          minWidth: '110px',
+                          textTransform: 'capitalize',
+                        }}
+                      >
+                        {row.label}
+                      </Typography>
+                      <TextP
+                        sx={{
+                          flex: 1,
+                          fontSize: '15px',
+                          fontWeight: 600,
+                          lineHeight: 1.35,
+                          textAlign: 'right',
+                        }}
+                      >
+                        {row.value}
+                      </TextP>
+                    </>
+                  ) : (
+                    <TextP
+                      sx={{
+                        fontSize: '15px',
+                        fontWeight: 600,
+                        lineHeight: 1.45,
+                      }}
+                    >
+                      {row.value}
+                    </TextP>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+          {showHtmlInSummary && (
+            <Box
+              sx={{
+                '& *': {
+                  color: `${theme.palette.text.primary} !important`,
+                  fontFamily: 'Inter, sans-serif !important',
+                },
+                '& p, & li, & span': {
+                  color: `${theme.palette.text.secondary} !important`,
+                  lineHeight: '1.45 !important',
+                },
+                '& ul, & ol': {
+                  margin: 0,
+                  paddingLeft: '18px',
+                },
+              }}
+              dangerouslySetInnerHTML={{ __html: typedMessage.html as string }}
+            />
+          )}
+          {feeRows.length > 0 && (
+            <Box
+              sx={{
+                borderTop: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '10px',
+                paddingTop: '16px',
+              }}
+            >
+              {feeRows.map((row, index) => (
+                <Box
+                  key={`${row.label}-${index}`}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: '12px',
+                  }}
+                >
+                  <Typography sx={{ color: theme.palette.text.secondary, fontSize: '13px' }}>
+                    {row.label}
+                  </Typography>
+                  <TextP sx={{ fontSize: '14px', fontWeight: 700 }}>{row.value}</TextP>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+        {(typedMessage.checkbox1 || typedMessage.confirmCheckbox) && (
+          <>
+            <Spacer height="16px" />
+            <Box
+              sx={{
+                backgroundColor: alpha(theme.palette.background.default, 0.38),
+                border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                borderRadius: '16px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '4px',
+                padding: '10px 14px',
+                width: '100%',
+              }}
+            >
+              {typedMessage.checkbox1 && (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      onChange={(e) => onCheckbox1Change(e.target.checked)}
+                      edge="start"
+                      tabIndex={-1}
+                      disableRipple
+                      defaultChecked={typedMessage.checkbox1?.value}
+                      sx={{
+                        '&.Mui-checked': {
+                          color: theme.palette.text.secondary,
+                        },
+                        '& .MuiSvgIcon-root': {
+                          color: theme.palette.text.secondary,
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px' }}>
+                      {typedMessage.checkbox1?.label}
+                    </Typography>
+                  }
+                  sx={{ margin: 0 }}
+                />
+              )}
+              {typedMessage.confirmCheckbox && (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      onChange={(e) => onConfirmRequestReadChange(e.target.checked)}
+                      checked={confirmRequestRead}
+                      edge="start"
+                      tabIndex={-1}
+                      disableRipple
+                      sx={{
+                        '&.Mui-checked': {
+                          color: theme.palette.text.secondary,
+                        },
+                        '& .MuiSvgIcon-root': {
+                          color: theme.palette.text.secondary,
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Box sx={{ alignItems: 'center', display: 'flex', gap: '8px' }}>
+                      <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px' }}>
+                        {typedMessage.confirmCheckboxLabel ||
+                          t('core:message.success.request_read', {
+                            postProcess: 'capitalizeFirstChar',
+                          })}
+                      </Typography>
+                      <PriorityHighIcon color="warning" sx={{ fontSize: '18px' }} />
+                    </Box>
+                  }
+                  sx={{ margin: 0 }}
+                />
+              )}
+            </Box>
+          </>
+        )}
+        {hasDetailsAccordion && (
+          <>
+            <Spacer height="16px" />
+            <Accordion
+              sx={{
+                backgroundColor: alpha(theme.palette.background.default, 0.28),
+                backgroundImage: 'none',
+                border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                borderRadius: '16px !important',
+                boxShadow: 'none',
+                color: theme.palette.text.primary,
+                width: '100%',
+                '&:before': {
+                  display: 'none',
+                },
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMoreRoundedIcon sx={{ color: theme.palette.text.secondary }} />}
+                sx={{
+                  minHeight: '56px',
+                  padding: '0 18px',
+                  '& .MuiAccordionSummary-content': {
+                    margin: '14px 0',
                   },
                 }}
-              />
-            }
-            label={
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <Typography sx={{ fontSize: '14px' }}>
-                  {message.confirmCheckboxLabel ||
-                    t('core:message.success.request_read', {
-                      postProcess: 'capitalizeFirstChar',
-                    })}
+              >
+                <Typography
+                  sx={{
+                    color: theme.palette.text.primary,
+                    fontSize: '15px',
+                    fontWeight: 700,
+                  }}
+                >
+                  Technical details
                 </Typography>
-                <PriorityHighIcon color="warning" />
-              </Box>
-            }
-          />
+              </AccordionSummary>
+              <AccordionDetails sx={{ padding: '0 18px 18px' }}>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+                  {accordionDetailRows.map((row, index) => (
+                    <Box
+                      key={`${row.label || row.value}-${index}`}
+                      sx={{
+                        borderBottom:
+                          index !== accordionDetailRows.length - 1 ||
+                          typedMessage.html ||
+                          typedMessage.json
+                            ? `1px solid ${alpha(theme.palette.common.white, 0.08)}`
+                            : 'none',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '4px',
+                        paddingBottom: '12px',
+                      }}
+                    >
+                      {row.label && (
+                        <Typography
+                          sx={{
+                            color: theme.palette.text.secondary,
+                            fontSize: '12px',
+                            fontWeight: 700,
+                            letterSpacing: '0.05em',
+                            textTransform: 'uppercase',
+                          }}
+                        >
+                          {row.label}
+                        </Typography>
+                      )}
+                      <TextP sx={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.45 }}>
+                        {row.value}
+                      </TextP>
+                    </Box>
+                  ))}
+                  {!!typedMessage.html && !showHtmlInSummary && (
+                    <Box
+                      sx={{
+                        '& *': {
+                          color: `${theme.palette.text.primary} !important`,
+                          fontFamily: 'Inter, sans-serif !important',
+                        },
+                        '& p, & li, & span': {
+                          color: `${theme.palette.text.secondary} !important`,
+                          lineHeight: '1.45 !important',
+                        },
+                        '& ul, & ol': {
+                          margin: 0,
+                          paddingLeft: '18px',
+                        },
+                      }}
+                      dangerouslySetInnerHTML={{ __html: typedMessage.html as string }}
+                    />
+                  )}
+                  {typedMessage.json && (
+                    <Box
+                      sx={{
+                        border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+                        borderRadius: '12px',
+                        overflow: 'auto',
+                        padding: '10px',
+                      }}
+                    >
+                      <JsonView
+                        data={typedMessage.json}
+                        shouldExpandNode={allExpanded}
+                        style={darkStyles}
+                      />
+                    </Box>
+                  )}
+                </Box>
+              </AccordionDetails>
+            </Accordion>
+          </>
         )}
-        <Spacer height="29px" />
+        <Spacer height="22px" />
         <Box
           sx={{
             alignItems: 'center',
             display: 'flex',
-            gap: '14px',
+            gap: '12px',
+            justifyContent: 'flex-end',
+            width: '100%',
           }}
         >
           <CustomButtonAccept
             customColor="black"
+            customBgColor={alpha(theme.palette.other.danger, 0.9)}
+            sx={{
+              minWidth: '118px',
+              opacity: 0.92,
+            }}
+            onClick={onCancel}
+          >
+            {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
+          </CustomButtonAccept>
+          <CustomButtonAccept
+            customColor="black"
             customBgColor={theme.palette.other.positive}
             sx={{
-              minWidth: '102px',
-              opacity:
-                message?.confirmCheckbox && !confirmRequestRead ? 0.1 : 0.7,
-              cursor:
-                message?.confirmCheckbox && !confirmRequestRead
-                  ? 'default'
-                  : 'pointer',
+              minWidth: '118px',
+              opacity: canAccept ? 1 : 0.35,
+              cursor: canAccept ? 'pointer' : 'default',
               '&:hover': {
-                opacity:
-                  message?.confirmCheckbox && !confirmRequestRead ? 0.1 : 1,
+                opacity: canAccept ? 1 : 0.35,
               },
             }}
             onClick={onAccept}
           >
             {t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
           </CustomButtonAccept>
-          <CustomButtonAccept
-            customColor="black"
-            customBgColor={theme.palette.other.danger}
-            sx={{ minWidth: '102px' }}
-            onClick={onCancel}
-          >
-            {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
-          </CustomButtonAccept>
         </Box>
-        <ErrorText>{sendPaymentError}</ErrorText>
+        <ErrorText sx={{ marginTop: '12px', width: '100%' }}>{sendPaymentError}</ErrorText>
       </Box>
     </Dialog>
   );

--- a/src/components/App/qortalPermissionPresentation.ts
+++ b/src/components/App/qortalPermissionPresentation.ts
@@ -1,0 +1,522 @@
+export type PermissionDetailRow = {
+  label?: string;
+  value: string;
+};
+
+export type PermissionDetailSection = {
+  title?: string;
+  rows?: PermissionDetailRow[];
+  html?: string;
+  json?: any;
+};
+
+export type MessageQortalRequestExtension = {
+  text1?: string;
+  text2?: string;
+  text3?: string;
+  text4?: string;
+  html?: string;
+  highlightedText?: string;
+  json?: any;
+  fee?: string;
+  appFee?: string;
+  foreignFee?: string;
+  checkbox1?: { label?: string; value?: boolean };
+  confirmCheckbox?: boolean;
+  confirmCheckboxLabel?: string;
+  requestType?: string;
+  sourceLabel?: string;
+  sourceKind?: 'Q-App' | 'Application' | 'Extension';
+  summaryTitle?: string;
+  summaryBody?: string;
+  summaryItems?: PermissionDetailRow[];
+  technicalDetails?: PermissionDetailSection[];
+  countdownDuration?: number;
+};
+
+export type PermissionPresentation = {
+  sourceLabel?: string;
+  sourceKind: string;
+  title: string;
+  body: string;
+  summaryItems: PermissionDetailRow[];
+  feeItems: PermissionDetailRow[];
+  detailsSections: PermissionDetailSection[];
+};
+
+export const MODAL_REQUEST_TYPES = [
+  'ADD_FOREIGN_SERVER',
+  'ADD_GROUP_ADMIN',
+  'ADD_LIST_ITEMS',
+  'ADMIN_ACTION',
+  'BAN_FROM_GROUP',
+  'BUY_NAME',
+  'CANCEL_GROUP_BAN',
+  'CANCEL_GROUP_INVITE',
+  'CANCEL_SELL_NAME',
+  'CANCEL_TRADE_SELL_ORDER',
+  'CREATE_GROUP',
+  'CREATE_POLL',
+  'CREATE_TRADE_BUY_ORDER',
+  'CREATE_TRADE_SELL_ORDER',
+  'DELETE_HOSTED_DATA',
+  'DELETE_LIST_ITEM',
+  'DEPLOY_AT',
+  'GET_HOSTED_DATA',
+  'GET_LIST_ITEMS',
+  'GET_USER_ACCOUNT',
+  'GET_USER_WALLET',
+  'GET_USER_WALLET_INFO',
+  'GET_USER_WALLET_TRANSACTIONS',
+  'GET_WALLET_BALANCE',
+  'INVITE_TO_GROUP',
+  'JOIN_GROUP',
+  'KICK_FROM_GROUP',
+  'LEAVE_GROUP',
+  'LOCK_TAB',
+  'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA',
+  'PUBLISH_MULTIPLE_QDN_RESOURCES',
+  'PUBLISH_QDN_RESOURCE',
+  'REENCRYPT_GROUP_KEYS',
+  'REGISTER_NAME',
+  'REMOVE_FOREIGN_SERVER',
+  'REMOVE_GROUP_ADMIN',
+  'SAVE_FILE',
+  'SELL_NAME',
+  'SEND_CHAT_MESSAGE',
+  'SEND_COIN',
+  'SESSION_PERMISSIONS',
+  'SET_CURRENT_FOREIGN_SERVER',
+  'SIGN_FOREIGN_FEES',
+  'SIGN_TRANSACTION',
+  'TRANSFER_ASSET',
+  'UPDATE_FOREIGN_FEE',
+  'UPDATE_GROUP',
+  'UPDATE_NAME',
+  'VOTE_ON_POLL',
+] as const;
+
+const REQUEST_ACTION_LABELS: Record<string, string> = {
+  ADD_FOREIGN_SERVER: 'add a server',
+  ADD_GROUP_ADMIN: 'add a group admin',
+  ADD_LIST_ITEMS: 'add items to a list',
+  ADMIN_ACTION: 'perform an admin action',
+  BAN_FROM_GROUP: 'ban a user from a group',
+  BUY_NAME: 'buy a name',
+  CANCEL_GROUP_BAN: 'cancel a group ban',
+  CANCEL_GROUP_INVITE: 'cancel a group invite',
+  CANCEL_SELL_NAME: 'cancel a name sale',
+  CANCEL_TRADE_SELL_ORDER: 'cancel a trade sell order',
+  CREATE_GROUP: 'create a group',
+  CREATE_POLL: 'create a poll',
+  CREATE_TRADE_BUY_ORDER: 'create a trade buy order',
+  CREATE_TRADE_SELL_ORDER: 'create a trade sell order',
+  DELETE_HOSTED_DATA: 'delete hosted data',
+  DELETE_LIST_ITEM: 'delete a list item',
+  DEPLOY_AT: 'deploy an AT',
+  GET_USER_ACCOUNT: 'authenticate',
+  GET_HOSTED_DATA: 'access hosted data',
+  GET_LIST_ITEMS: 'access list items',
+  SESSION_PERMISSIONS: 'request session permissions',
+  INVITE_TO_GROUP: 'invite to a group',
+  PUBLISH_QDN_RESOURCE: 'publish data',
+  PUBLISH_MULTIPLE_QDN_RESOURCES: 'publish multiple resources',
+  KICK_FROM_GROUP: 'remove a user from a group',
+  LOCK_TAB: 'lock this tab',
+  REMOVE_FOREIGN_SERVER: 'remove a server',
+  REMOVE_GROUP_ADMIN: 'remove a group admin',
+  SAVE_FILE: 'save a file',
+  SELL_NAME: 'sell a name',
+  SEND_COIN: 'send a payment',
+  SET_CURRENT_FOREIGN_SERVER: 'change server settings',
+  SIGN_TRANSACTION: 'sign a transaction',
+  SIGN_FOREIGN_FEES: 'sign foreign fees',
+  MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA: 'send a payment and publish private data',
+  GET_USER_WALLET: 'access wallet details',
+  GET_WALLET_BALANCE: 'access wallet balances',
+  GET_USER_WALLET_INFO: 'access wallet information',
+  GET_USER_WALLET_TRANSACTIONS: 'access wallet transactions',
+  TRANSFER_ASSET: 'transfer an asset',
+  UPDATE_FOREIGN_FEE: 'update foreign fees',
+  UPDATE_GROUP: 'update a group',
+  REGISTER_NAME: 'register a name',
+  UPDATE_NAME: 'update a name',
+  JOIN_GROUP: 'join a group',
+  LEAVE_GROUP: 'leave a group',
+  SEND_CHAT_MESSAGE: 'send a chat message',
+  VOTE_ON_POLL: 'vote on a poll',
+};
+
+const formatServiceName = (service?: string) => {
+  if (!service) return 'Unknown';
+  return service
+    .toLowerCase()
+    .split('_')
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const QDN_SERVICE_SUMMARIES: Record<string, string> = {
+  APP: 'This publishes a Q-App resource to QDN.',
+  DOCUMENT: 'This publishes document-style content to QDN.',
+  DOCUMENT_PRIVATE: 'This publishes encrypted private document data to QDN.',
+  IMAGE: 'This publishes image data to QDN.',
+  VIDEO: 'This publishes video content to QDN.',
+  THUMBNAIL: 'This publishes thumbnail-style media to QDN.',
+  WEBSITE: 'This publishes website content to QDN.',
+  BLOG: 'This publishes blog content to QDN.',
+};
+
+const humanizeRequestType = (requestType?: string) => {
+  if (!requestType) return 'make a change to your account';
+  if (REQUEST_ACTION_LABELS[requestType]) return REQUEST_ACTION_LABELS[requestType];
+  return 'make a change to your account';
+};
+
+const sanitizeQuestionCopy = (value?: string) => {
+  if (!value) return '';
+
+  return value
+    .replace(/^do you give this application permission to\s*/i, '')
+    .replace(/^this application is requesting\s*/i, '')
+    .replace(/\?$/u, '')
+    .trim();
+};
+
+const parseDetailRow = (value?: string): PermissionDetailRow | null => {
+  if (!value?.trim()) return null;
+
+  const trimmed = value.trim();
+  const separatorIndex = trimmed.indexOf(':');
+
+  if (separatorIndex > 0) {
+    return {
+      label: trimmed.slice(0, separatorIndex).trim(),
+      value: trimmed.slice(separatorIndex + 1).trim() || '-',
+    };
+  }
+
+  return {
+    value: trimmed,
+  };
+};
+
+const getDetailRowValue = (
+  rows: PermissionDetailRow[],
+  targetLabel: string
+) => {
+  return rows.find((row) => row.label?.toLowerCase() === targetLabel.toLowerCase())?.value;
+};
+
+const parsePublishMultipleSummary = (html?: string) => {
+  if (!html) {
+    return { resourceCount: 0, includesPrivateData: false };
+  }
+
+  const resourceCount = (html.match(/resource-container/g) || []).length;
+  const includesPrivateData = /_PRIVATE|encrypted/iu.test(html);
+
+  return {
+    resourceCount,
+    includesPrivateData,
+  };
+};
+
+const getJsonValue = (json: any, candidateKeys: string[]) => {
+  if (!json || typeof json !== 'object') return undefined;
+
+  for (const key of candidateKeys) {
+    if (json[key] != null) {
+      return json[key];
+    }
+  }
+
+  return undefined;
+};
+
+const buildTitle = (message: MessageQortalRequestExtension) => {
+  if (message.summaryTitle) return message.summaryTitle;
+
+  const sourceLabel = message.sourceLabel?.trim();
+  const requestType = message.requestType;
+  const actionLabel = humanizeRequestType(requestType);
+
+  if (sourceLabel) {
+    return `${sourceLabel} wants to ${actionLabel}`;
+  }
+
+  const sanitized = sanitizeQuestionCopy(message.text1);
+  return `This application wants to ${REQUEST_ACTION_LABELS[requestType || ''] || sanitized || actionLabel}`;
+};
+
+const buildBody = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  if (message.summaryBody) return message.summaryBody;
+
+  const requestType = message.requestType;
+  const serviceRow = parseDetailRow(message.text2);
+  const serviceValue = serviceRow?.label?.toLowerCase() === 'service' ? serviceRow.value : '';
+
+  switch (requestType) {
+    case 'GET_USER_ACCOUNT':
+      return 'This app can confirm your Qortal identity. It cannot send payments or publish data.';
+    case 'SESSION_PERMISSIONS':
+      return 'Approved permissions can run automatically for this session only.';
+    case 'ADD_FOREIGN_SERVER':
+      return 'This adds a foreign server configuration to your Qortal environment.';
+    case 'PUBLISH_QDN_RESOURCE':
+      return (
+        QDN_SERVICE_SUMMARIES[serviceValue] ||
+        `This action will publish data to QDN using the ${serviceValue || 'selected'} service.`
+      );
+    case 'PUBLISH_MULTIPLE_QDN_RESOURCES':
+      return 'Multiple QDN resources will be published using your account.';
+    case 'SEND_COIN':
+      return 'This sends funds from your wallet to the specified recipient.';
+    case 'SIGN_TRANSACTION':
+      return 'This app wants your account to sign a transaction.';
+    case 'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA':
+      return 'This will send a payment and publish private encrypted data in the same action.';
+    case 'REMOVE_FOREIGN_SERVER':
+      return 'This removes a saved foreign server configuration from your Qortal environment.';
+    case 'SET_CURRENT_FOREIGN_SERVER':
+      return 'This changes which foreign server your Qortal environment will use.';
+    case 'GET_USER_WALLET':
+    case 'GET_WALLET_BALANCE':
+    case 'GET_USER_WALLET_INFO':
+    case 'GET_USER_WALLET_TRANSACTIONS':
+      return 'This gives the application access to wallet-related information from your Qortal account.';
+    default:
+      return 'Review the details of this action before approving.';
+  }
+};
+
+const buildSummaryItems = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  if (message.summaryItems?.length) return message.summaryItems;
+
+  const requestType = message.requestType;
+  const rows = [message.text2, message.text3, message.text4]
+    .map(parseDetailRow)
+    .filter(Boolean) as PermissionDetailRow[];
+
+  const serviceValue = getDetailRowValue(rows, 'service');
+  const nameValue = getDetailRowValue(rows, 'name');
+  const recipientValue = getDetailRowValue(rows, 'to');
+
+  if (requestType === 'GET_USER_ACCOUNT') {
+    return [
+      { value: 'This app can confirm your Qortal identity' },
+      { value: 'It cannot send payments' },
+      { value: 'It will not publish data' },
+    ];
+  }
+
+  if (requestType === 'SESSION_PERMISSIONS') {
+    return [
+      {
+        value: 'Approved permissions can run automatically for this session only',
+      },
+      { value: 'These permissions stop when the session ends' },
+    ];
+  }
+
+  if (requestType === 'ADD_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will add a foreign server configuration' },
+      { value: 'Make sure you trust the server details below.' },
+    ];
+  }
+
+  if (requestType === 'PUBLISH_QDN_RESOURCE') {
+    return [
+      { value: 'This will publish data to QDN using your account' },
+      ...(serviceValue ? [{ label: 'Content type', value: formatServiceName(serviceValue) }] : []),
+      ...(nameValue ? [{ label: 'Publishing name', value: nameValue }] : []),
+    ];
+  }
+
+  if (requestType === 'PUBLISH_MULTIPLE_QDN_RESOURCES') {
+    const { resourceCount, includesPrivateData } = parsePublishMultipleSummary(message.html);
+    return [
+      { value: 'Multiple QDN resources will be published using your account' },
+      ...(includesPrivateData
+        ? [{ value: 'Some resources include private or encrypted data' }]
+        : []),
+      ...(resourceCount > 0
+        ? [{ label: 'Resources in this request', value: `${resourceCount}` }]
+        : []),
+    ];
+  }
+
+  if (requestType === 'SEND_COIN') {
+    return [
+      ...(message.highlightedText ? [{ label: 'Amount', value: message.highlightedText }] : []),
+      ...(recipientValue ? [{ label: 'Recipient', value: recipientValue }] : []),
+    ];
+  }
+
+  if (
+    requestType === 'GET_USER_WALLET' ||
+    requestType === 'GET_USER_WALLET_INFO' ||
+    requestType === 'GET_USER_WALLET_TRANSACTIONS'
+  ) {
+    return [
+      { value: 'This app can view wallet-related information from your Qortal account' },
+      ...(message.highlightedText ? [{ label: 'Wallet', value: message.highlightedText.replace(/^coin:\s*/iu, '') }] : []),
+    ];
+  }
+
+  if (requestType === 'GET_WALLET_BALANCE') {
+    return [
+      { value: 'This app can view your wallet balance' },
+      ...(message.text1?.includes('{{ coin }}') ? [] : []),
+    ];
+  }
+
+  if (requestType === 'SIGN_TRANSACTION') {
+    const txType = getJsonValue(message.json, ['type']);
+    const recipient = getJsonValue(message.json, ['recipient', 'recipientAddress']);
+    const amount = getJsonValue(message.json, ['amount', 'amountQort']);
+    return [
+      { value: 'This app wants your account to sign a transaction' },
+      ...(txType != null ? [{ label: 'Transaction type', value: String(txType) }] : []),
+      ...(recipient != null ? [{ label: 'Recipient', value: String(recipient) }] : []),
+      ...(amount != null ? [{ label: 'Amount', value: String(amount) }] : []),
+    ];
+  }
+
+  if (requestType === 'REMOVE_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will remove a saved foreign server configuration' },
+      { value: 'Review the server details below before approving' },
+    ];
+  }
+
+  if (requestType === 'SET_CURRENT_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will change the foreign server currently in use' },
+      { value: 'Review the server details below before approving' },
+    ];
+  }
+
+  const summaryRows = rows.slice(0, message.highlightedText ? 1 : 2);
+  if (message.highlightedText) {
+    return [{ value: message.highlightedText }, ...summaryRows];
+  }
+
+  if (summaryRows.length > 0) {
+    return summaryRows;
+  }
+
+  return [
+    { value: 'This action will modify your Qortal account or data' },
+    { value: 'Review the technical details below before approving' },
+  ];
+};
+
+const buildFeeItems = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  const feeItems: PermissionDetailRow[] = [];
+
+  if (message.fee) {
+    feeItems.push({ label: 'Network fee', value: `${message.fee} QORT` });
+  }
+
+  if (message.appFee) {
+    feeItems.push({
+      label: t('core:message.generic.fee_qort', {
+        fee: message.appFee,
+        postProcess: 'capitalizeFirstChar',
+      }).split(':')[0] || 'App fee',
+      value: `${message.appFee} QORT`,
+    });
+  }
+
+  if (message.foreignFee) {
+    feeItems.push({
+      label: t('core:message.generic.foreign_fee', {
+        fee: message.foreignFee,
+        postProcess: 'capitalizeFirstChar',
+      }).split(':')[0] || 'Foreign fee',
+      value: message.foreignFee,
+    });
+  }
+
+  return feeItems;
+};
+
+const buildDetailsSections = (message: MessageQortalRequestExtension) => {
+  const sections: PermissionDetailSection[] = [];
+
+  const rows = [message.text2, message.text3, message.text4]
+    .map(parseDetailRow)
+    .filter(Boolean) as PermissionDetailRow[];
+
+  const summaryRows = buildSummaryItems(message, () => '');
+  const summaryKeys = new Set(summaryRows.map((row) => `${row.label}:${row.value}`));
+  const fallbackRows = rows.filter((row) => !summaryKeys.has(`${row.label}:${row.value}`));
+
+  const technicalRows: PermissionDetailRow[] = [];
+  const technicalKeys = new Set<string>();
+  const normalizeLabel = (label?: string) => (label || '').trim().toLowerCase();
+  const pushTechnicalRow = (row?: PermissionDetailRow | null) => {
+    if (!row) return;
+    const key = `${normalizeLabel(row.label)}:${row.value}`;
+    if (technicalKeys.has(key)) return;
+    technicalKeys.add(key);
+    technicalRows.push(row);
+  };
+
+  pushTechnicalRow(
+    message.requestType ? { label: 'Request type', value: message.requestType } : null
+  );
+
+  for (const section of message.technicalDetails || []) {
+    for (const row of section.rows || []) {
+      pushTechnicalRow(row);
+    }
+  }
+
+  for (const row of fallbackRows) {
+    pushTechnicalRow(row);
+  }
+
+  if (technicalRows.length > 0) {
+    sections.push({ title: 'Technical details', rows: technicalRows });
+  }
+
+  const shouldShowHtmlPayload =
+    !!message.html && message.requestType !== 'PUBLISH_MULTIPLE_QDN_RESOURCES';
+
+  if (shouldShowHtmlPayload) {
+    sections.push({ title: 'Request payload', html: message.html });
+  }
+
+  if (message.json) {
+    sections.push({ title: 'Raw payload', json: message.json });
+  }
+
+  return sections;
+};
+
+export const buildPermissionPresentation = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+): PermissionPresentation => {
+  return {
+    sourceLabel: message.sourceLabel,
+    sourceKind: message.sourceKind || 'Application',
+    title: buildTitle(message),
+    body: buildBody(message, t),
+    summaryItems: buildSummaryItems(message, t),
+    feeItems: buildFeeItems(message, t),
+    detailsSections: buildDetailsSections(message),
+  };
+};

--- a/src/components/Apps/AppViewer.tsx
+++ b/src/components/Apps/AppViewer.tsx
@@ -6,8 +6,8 @@ import { useFrame } from 'react-frame-component';
 import { useQortalMessageListener } from '../../hooks/useQortalMessageListener';
 import { useThemeContext } from '../Theme/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import { QORTAL_PROTOCOL } from '../../constants/constants';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
+import { buildQortalResourceLink } from '../../utils/qortalLink';
 
 type AppViewerProps = {
   app: any;
@@ -27,6 +27,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
         isDevMode,
         isDevMode ? 'devapp' : app?.name,
         app?.service,
+        app?.identifier,
         skipAuth
       );
 
@@ -133,8 +134,11 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
     const copyLinkFunc = (e) => {
       const { tabId } = e.detail;
       if (tabId === app?.tabId) {
-        let link =
-          QORTAL_PROTOCOL + app?.service + '/' + app?.name.replace(/ /g, '%20');
+        let link = buildQortalResourceLink({
+          service: app?.service,
+          name: app?.name,
+          identifier: app?.identifier,
+        });
         if (path && path.startsWith('/')) {
           link = link + removeTrailingSlash(path);
         }
@@ -325,6 +329,25 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
       }
     };
 
+    const navigateForwardAppFunc = () => {
+      navigateForwardInIframe();
+    };
+
+    useEffect(() => {
+      if (!app?.tabId) return;
+      subscribeToEvent(
+        `navigateForwardApp-${app?.tabId}`,
+        navigateForwardAppFunc
+      );
+
+      return () => {
+        unsubscribeFromEvent(
+          `navigateForwardApp-${app?.tabId}`,
+          navigateForwardAppFunc
+        );
+      };
+    }, [app?.tabId]);
+
     return (
       <Box
         sx={{
@@ -335,7 +358,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
         <iframe
           ref={iframeRef}
           style={{
-            height: `100vh`,
+            height: `calc(100vh - ${appChromeOffsetPx})`,
             border: 'none',
             width: '100%',
           }}

--- a/src/components/Apps/AppViewerContainer.tsx
+++ b/src/components/Apps/AppViewerContainer.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { AppViewer } from './AppViewer';
 import Frame from 'react-frame-component';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 type AppViewerContainerProps = {
   app: any;
@@ -44,7 +44,7 @@ const AppViewerContainer = forwardRef<
       }
       style={{
         border: 'none',
-        height: customHeight || `calc(100vh - ${appHeighOffsetPx})`,
+        height: customHeight || `calc(100vh - ${appChromeOffsetPx})`,
         left: (!isSelected || hide) && '-200vw',
         overflow: 'hidden',
         position: (!isSelected || hide) && 'fixed',

--- a/src/components/Apps/AppsCategoryDesktop.tsx
+++ b/src/components/Apps/AppsCategoryDesktop.tsx
@@ -22,8 +22,7 @@ import { ReturnIcon } from '../../assets/Icons/ReturnIcon';
 import { useAtom } from 'jotai';
 import { appSortAtom } from '../../atoms/appsAtoms';
 import { SortDropdown, SortOption } from './Filters';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 // Sorting function (same as CommunityAppsTab)
 const sortApps = (apps: any[], sortOption: SortOption): any[] => {
@@ -104,7 +103,7 @@ export const AppsCategoryDesktop = ({
     <AppsLibraryContainer
       sx={{
         display: !isShow && 'none',
-        height: `calc(100vh - ${appHeighOffsetPx} )`,
+        height: `calc(100vh - ${appChromeOffsetPx} )`,
         overflow: 'hidden',
         padding: '0px',
         paddingTop: '30px',
@@ -190,12 +189,12 @@ export const AppsCategoryDesktop = ({
       </AppsDesktopLibraryHeader>
 
       <AppsDesktopLibraryBody
-        sx={{
-          alignItems: 'center',
-          height: `calc(100vh - ${appHeighOffsetPx}  - 36px)`,
-          overflow: 'auto',
-          padding: '0px',
-          width: '90%',
+      sx={{
+        alignItems: 'center',
+        height: `calc(100vh - ${appChromeOffsetPx}  - 36px)`,
+        overflow: 'auto',
+        padding: '0px',
+        width: '90%',
           maxWidth: '1200px',
         }}
       >

--- a/src/components/Apps/AppsDesktop.tsx
+++ b/src/components/Apps/AppsDesktop.tsx
@@ -32,7 +32,6 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  useTheme,
 } from '@mui/material';
 import {
   enabledDevModeAtom,
@@ -43,8 +42,7 @@ import { publishEditTargetAtom } from '../../atoms/appsAtoms';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { TIME_MINUTES_20_IN_MILLISECONDS } from '../../constants/constants';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 const uid = new ShortUniqueId({ length: 8 });
 
@@ -65,9 +63,12 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
   const [isEnabledDevMode, setIsEnabledDevMode] = useAtom(enabledDevModeAtom);
   const { showTutorial } = useHandleTutorials();
   const { refreshRatings } = useAppRatings();
-  const theme = useTheme();
   const [showCloseTabDialog, setShowCloseTabDialog] = useState(false);
   const [pendingTabToRemove, setPendingTabToRemove] = useState(null);
+  const [librarySearchRequest, setLibrarySearchRequest] = useState<{
+    nonce: number;
+    query: string;
+  }>({ nonce: 0, query: '' });
   const { t } = useTranslation([
     'auth',
     'core',
@@ -428,6 +429,28 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
     };
   }, [tabs]);
 
+  const openAppsLibrarySearchFunc = useCallback((e) => {
+    const query = e.detail?.data?.query || '';
+    setSelectedTab(null);
+    setIsNewTabWindow(false);
+    setLibrarySearchRequest({
+      nonce: Date.now(),
+      query,
+    });
+    setMode('library');
+  }, []);
+
+  useEffect(() => {
+    subscribeToEvent('openAppsLibrarySearch', openAppsLibrarySearchFunc);
+
+    return () => {
+      unsubscribeFromEvent(
+        'openAppsLibrarySearch',
+        openAppsLibrarySearchFunc
+      );
+    };
+  }, [openAppsLibrarySearchFunc]);
+
   return (
     <AppsParent
       sx={{
@@ -442,7 +465,7 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            height: `calc(100vh - ${appHeighOffsetPx} )`,
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
             overflow: 'auto',
             width: '100%',
           }}
@@ -463,6 +486,7 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
       <AppsLibraryDesktop
         availableQapps={availableQapps}
         categories={categories}
+        externalSearchRequest={librarySearchRequest}
         getQapps={async () => { await getQapps(); refreshRatings(); }}
         hasPublishApp={!!(myApp || myWebsite)}
         isShow={mode === 'library' && !selectedTab}
@@ -527,12 +551,12 @@ export const AppsDesktop = ({ mode, setMode, show }) => {
         <>
           <Box
             sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: `calc(100vh - ${appHeighOffsetPx} )`,
-              overflow: 'auto',
-              width: '100%',
-            }}
+            display: 'flex',
+            flexDirection: 'column',
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
+            overflow: 'auto',
+            width: '100%',
+          }}
           >
             <Spacer height="30px" />
 

--- a/src/components/Apps/AppsDevMode.tsx
+++ b/src/components/Apps/AppsDevMode.tsx
@@ -11,10 +11,9 @@ import {
 import { AppsParent } from './Apps-styles';
 import AppViewerContainer from './AppViewerContainer';
 import ShortUniqueId from 'short-unique-id';
-import { Box, useTheme } from '@mui/material';
+import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 const uid = new ShortUniqueId({ length: 8 });
 
@@ -44,7 +43,6 @@ export const AppsDevMode = ({
   const [isNewTabWindow, setIsNewTabWindow] = useState(false);
   const [categories, setCategories] = useState([]);
   const iframeRefs = useRef({});
-  const theme = useTheme();
   const { t } = useTranslation([
     'auth',
     'core',
@@ -229,7 +227,7 @@ export const AppsDevMode = ({
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            height: `calc(100vh - ${appHeighOffsetPx} )`,
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
             overflow: 'auto',
             width: 'auto',
           }}
@@ -265,13 +263,13 @@ export const AppsDevMode = ({
       {isNewTabWindow && mode === 'viewer' && (
         <>
           <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: `calc(100vh - ${appHeighOffsetPx} )`,
-              overflow: 'auto',
-              width: 'auto',
-            }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: `calc(100vh - ${appChromeOffsetPx} )`,
+            overflow: 'auto',
+            width: 'auto',
+          }}
           >
             <Spacer height="30px" />
 

--- a/src/components/Apps/AppsLibraryDesktop.tsx
+++ b/src/components/Apps/AppsLibraryDesktop.tsx
@@ -25,6 +25,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import IconClearInput from '../../assets/svgs/ClearInput.svg';
 import { useAtom } from 'jotai';
 import { appSortAtom } from '../../atoms/appsAtoms';
+import { filterAndSortApps } from '../../atoms/appsAtoms';
 import {
   SortDropdown,
   CategoryFilter,
@@ -40,8 +41,8 @@ import {
   MyAppsTab,
   PrivateTab,
 } from './AppsLibrary';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
-import { APPS_BOTTOM_NAV_HEIGHT_PX } from './Apps-styles';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
+import { AppCardEnhanced } from './AppCard';
 
 const SearchContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -62,6 +63,7 @@ export const AppsLibraryDesktop = ({
   isShow,
   categories,
   getQapps,
+  externalSearchRequest,
 }) => {
   const [currentTab, setCurrentTab] = useState<AppsLibraryTabValue>('official');
   const [searchValue, setSearchValue] = useState('');
@@ -85,11 +87,69 @@ export const AppsLibraryDesktop = ({
     return () => clearTimeout(handler);
   }, [searchValue]);
 
+  useEffect(() => {
+    if (!externalSearchRequest?.query) return;
+    setSearchValue(externalSearchRequest.query);
+    setDebouncedSearchValue(externalSearchRequest.query);
+  }, [externalSearchRequest?.nonce]);
+
   const handleTabChange = (tab: AppsLibraryTabValue) => {
     setCurrentTab(tab);
   };
 
   const renderTabContent = () => {
+    if (debouncedSearchValue.trim()) {
+      const combinedResults = filterAndSortApps(availableQapps, {
+        sort: sortOption,
+        category: 'all',
+        status: 'all',
+        search: debouncedSearchValue,
+      });
+
+      return (
+        <AppsWidthLimiter>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+            }}
+          >
+            <Box
+              sx={{
+                color: theme.palette.text.primary,
+                fontSize: '20px',
+                fontWeight: 600,
+              }}
+            >
+              {t('core:action.search_apps', {
+                postProcess: 'capitalizeFirstChar',
+              })}{' '}
+              ({combinedResults.length})
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gap: '16px',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+              width: '100%',
+            }}
+          >
+            {combinedResults.map((app) => (
+              <AppCardEnhanced
+                key={`${app?.service}-${app?.name}`}
+                app={app}
+                myName={myName}
+              />
+            ))}
+          </Box>
+        </AppsWidthLimiter>
+      );
+    }
+
     switch (currentTab) {
       case 'official':
         return (
@@ -146,7 +206,7 @@ export const AppsLibraryDesktop = ({
       sx={{
         display: !isShow && 'none',
         padding: '0px',
-        height: `calc(100vh - ${appHeighOffsetPx} )`,
+        height: `calc(100vh - ${appChromeOffsetPx} )`,
         overflow: 'hidden',
         paddingTop: '30px',
       }}

--- a/src/components/Chat/MessageDisplay.tsx
+++ b/src/components/Chat/MessageDisplay.tsx
@@ -23,19 +23,31 @@ export const extractComponents = (url: string) => {
   // If nothing meaningful left (e.g., "qortal://", "qortal:////"), return null
   if (!/[^/]/.test(url)) return null;
 
-  // Case 1: url contains a slash → already service-based
+  // Case 1: url contains a slash -> already service-based
   if (url.includes('/')) {
-    const parts = url.split('/');
+    // Identifier is part of QDN resource identity when present. Keep older
+    // links without identifier working, and route future reopen flows here.
+    const [basePart, queryString = ''] = url.split('?');
+    const parts = basePart.split('/');
     const service = parts[0].toUpperCase();
     parts.shift();
     const name = parts[0];
     parts.shift();
-    let identifier;
-    const path = parts.join('/');
+
+    const params = new URLSearchParams(queryString);
+    const identifier = params.get('identifier') || undefined;
+    if (identifier) {
+      params.delete('identifier');
+    }
+
+    const remainingQuery = params.toString();
+    const basePath = parts.join('/');
+    const path = `${basePath}${remainingQuery ? `?${remainingQuery}` : ''}`;
+
     return { service, name, identifier, path };
   }
 
-  // Case 2: url is just a username → default to WEBSITE
+  // Case 2: url is just a username -> default to WEBSITE
   return {
     service: 'WEBSITE',
     name: url,
@@ -78,7 +90,7 @@ function processText(input) {
 }
 
 const linkify = (text) => {
-  if (!text) return ''; // Return an empty string if text is null or undefined
+  if (!text) return '';
   let textFormatted = text;
   const urlPattern = /(\bhttps?:\/\/[^\s<]+|\bwww\.[^\s<]+)/g;
   textFormatted = text.replace(urlPattern, (url) => {
@@ -158,7 +170,12 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
   const handleClickCapture = (e) => {
     if (isReply) {
       const target = e.target;
-      const isLink = target.tagName === 'A' || target.getAttribute?.('data-url') || target.closest?.('a') || target.closest?.('.qortal-link') || target.closest?.('[data-url]');
+      const isLink =
+        target.tagName === 'A' ||
+        target.getAttribute?.('data-url') ||
+        target.closest?.('a') ||
+        target.closest?.('.qortal-link') ||
+        target.closest?.('[data-url]');
       if (isLink) {
         e.preventDefault();
         e.stopPropagation();
@@ -170,7 +187,12 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
     if (isReply) {
       e.preventDefault();
       const target = e.target;
-      const isLink = target.tagName === 'A' || target.getAttribute?.('data-url') || target.closest?.('a') || target.closest?.('.qortal-link') || target.closest?.('[data-url]');
+      const isLink =
+        target.tagName === 'A' ||
+        target.getAttribute?.('data-url') ||
+        target.closest?.('a') ||
+        target.closest?.('.qortal-link') ||
+        target.closest?.('[data-url]');
       if (isLink) {
         e.stopPropagation();
         return;
@@ -195,12 +217,11 @@ export const MessageDisplay = ({ htmlContent, isReply = false }) => {
       try {
         copyUrl = copyUrl.replace(/^(qortal:\/\/)/, '');
         if (copyUrl.startsWith('use-')) {
-          // Handle the new 'use' format
           const parts = copyUrl.split('/');
           parts.shift();
-          const action = parts.length > 0 ? parts[0].split('-')[1] : null; // e.g., 'invite' from 'action-invite'
+          const action = parts.length > 0 ? parts[0].split('-')[1] : null;
           parts.shift();
-          const id = parts.length > 0 ? parts[0].split('-')[1] : null; // e.g., '321' from 'groupid-321'
+          const id = parts.length > 0 ? parts[0].split('-')[1] : null;
           if (action === 'join') {
             executeEvent('globalActionJoinGroup', { groupId: id });
             return;

--- a/src/components/Desktop/CustomTitleBar.tsx
+++ b/src/components/Desktop/CustomTitleBar.tsx
@@ -27,12 +27,15 @@ import { GlobalActions } from '../GlobalActions/GlobalActions';
 import { ChatWidgetReopenIcon } from '../Profile/ChatWidgetReopenIcon';
 
 const TITLE_BAR_HEIGHT = 32;
+export const APP_NAV_BAR_HEIGHT = 48;
 /** Left offset so title-bar nav aligns with content vertical line (DesktopLeftSideBar width). */
 const TITLE_BAR_LEFT_OFFSET_PX = 70;
 const TITLE_BAR_MENU_WIDTH_PX = 40;
 export const CUSTOM_TITLE_BAR_HEIGHT = TITLE_BAR_HEIGHT;
 export const appHeighOffsetPx = `${TITLE_BAR_HEIGHT}px`;
 export const appHeighOffset = TITLE_BAR_HEIGHT;
+export const appChromeOffsetPx = `${TITLE_BAR_HEIGHT + APP_NAV_BAR_HEIGHT}px`;
+export const appChromeOffset = TITLE_BAR_HEIGHT + APP_NAV_BAR_HEIGHT;
 declare global {
   interface Window {
     electronAPI?: {

--- a/src/components/Desktop/DesktopLeftSideBar.tsx
+++ b/src/components/Desktop/DesktopLeftSideBar.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { AppsNavBarDesktop } from '../Apps/AppsNavBarDesktop';
 import { AppsDevModeNavBar } from '../Apps/AppsDevModeNavBar';
 import { executeEvent } from '../../utils/events';
-import { appHeighOffsetPx } from './CustomTitleBar';
+import { appChromeOffsetPx } from './CustomTitleBar';
 
 export const DesktopSideBar = ({
   goToHome,
@@ -55,7 +55,7 @@ export const DesktopSideBar = ({
         display: 'flex',
         flexDirection: 'column',
         gap: '25px',
-        height: `calc(100vh - ${appHeighOffsetPx})`,
+        height: `calc(100vh - ${appChromeOffsetPx})`,
         width: 'auto', // must adapt to the chosen language
       }}
     >

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -45,7 +45,10 @@ export function GlobalQortalNavBar({
   const { t } = useTranslation(['core']);
   const [selectedTab, setSelectedTab] = useState<SelectedTab>(null);
   const [inputValue, setInputValue] = useState('');
+  const [isInputHovered, setIsInputHovered] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const isInputFocusedRef = useRef(false);
+  const inputElementRef = useRef<HTMLInputElement | null>(null);
 
   const setTabsToNav = useCallback((e: CustomEvent) => {
     const nextSelectedTab = e.detail?.data?.selectedTab;
@@ -118,8 +121,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.82)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(70, 73, 79, 0.96)'
-      : 'rgba(255, 255, 255, 0.9)';
+      ? 'rgba(68, 71, 77, 0.94)'
+      : 'rgba(255, 255, 255, 0.88)';
   const hoverBorderColor =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.16)'
@@ -130,16 +133,46 @@ export function GlobalQortalNavBar({
       : 'rgba(0, 0, 0, 0.2)';
   const inputHoverShadow =
     theme.palette.mode === 'dark'
-      ? '0 0 0 1px rgba(255, 255, 255, 0.03), 0 8px 18px rgba(0, 0, 0, 0.14)'
-      : '0 0 0 1px rgba(255, 255, 255, 0.08), 0 8px 18px rgba(120, 127, 140, 0.12)';
+      ? `0 0 0 1px rgba(94, 154, 255, 0.3), 0 0 0 3px rgba(94, 154, 255, 0.12)`
+      : `0 0 0 1px rgba(41, 121, 218, 0.28), 0 0 0 3px rgba(41, 121, 218, 0.1)`;
   const inputFocusShadow =
     theme.palette.mode === 'dark'
-      ? '0 0 0 1px rgba(255, 255, 255, 0.06), 0 10px 24px rgba(0, 0, 0, 0.2)'
-      : '0 0 0 1px rgba(255, 255, 255, 0.12), 0 10px 24px rgba(120, 127, 140, 0.16)';
+      ? 'none'
+      : 'none';
   const buttonHoverBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.06)'
       : 'rgba(0, 0, 0, 0.05)';
+  const inputTextDefaultColor = theme.palette.text.secondary;
+  const inputTextHoverColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(224, 224, 224, 0.92)'
+      : 'rgba(0, 0, 0, 0.72)';
+  const inputTextFocusColor = theme.palette.text.primary;
+  const inputTextColor = isInputFocused
+    ? inputTextFocusColor
+    : isInputHovered
+      ? inputTextHoverColor
+      : inputTextDefaultColor;
+  const placeholderColor = isInputFocused
+    ? inputTextHoverColor
+    : theme.palette.text.secondary;
+  const selectionBackground = theme.palette.primary.main;
+  const selectionColor =
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.92)' : '#ffffff';
+  const showStyledLinkPreview =
+    !isInputFocused && !!inputValue && /^qortal:\/\//i.test(inputValue);
+  const protocolMatch = inputValue.match(/^(qortal:\/\/)/i);
+  const protocolText = protocolMatch?.[0] || '';
+  const remainderText = protocolText ? inputValue.slice(protocolText.length) : '';
+  const protocolColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(224, 224, 224, 0.92)'
+      : 'rgba(0, 0, 0, 0.74)';
+  const remainderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(176, 176, 176, 0.9)'
+      : 'rgba(0, 0, 0, 0.56)';
 
   return (
     <Box
@@ -200,11 +233,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canGoBack ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -226,11 +258,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canGoForward ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -258,11 +289,10 @@ export function GlobalQortalNavBar({
               justifyContent: 'center',
               opacity: canRefresh ? 1 : 0.32,
               transition:
-                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease',
               width: 32,
               '&:hover:not(.Mui-disabled)': {
                 backgroundColor: buttonHoverBackground,
-                transform: 'translateY(-1px)',
               },
             }}
           >
@@ -271,6 +301,8 @@ export function GlobalQortalNavBar({
         </Box>
 
         <Box
+          onMouseEnter={() => setIsInputHovered(true)}
+          onMouseLeave={() => setIsInputHovered(false)}
           sx={{
             alignItems: 'center',
             backgroundColor: inputBackground,
@@ -284,18 +316,16 @@ export function GlobalQortalNavBar({
             px: 1.5,
             boxShadow: 'none',
             transition:
-              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease, transform 280ms ease',
+              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease',
             '&:hover': {
               backgroundColor: inputHoverBackground,
               borderColor: hoverBorderColor,
               boxShadow: inputHoverShadow,
-              transform: 'translateY(-1px)',
             },
             '&:focus-within': {
               backgroundColor: inputFocusBackground,
               borderColor: focusBorderColor,
               boxShadow: inputFocusShadow,
-              transform: 'translateY(-1px)',
             },
           }}
         >
@@ -305,38 +335,99 @@ export function GlobalQortalNavBar({
               fontSize: 17,
             }}
           />
-          <InputBase
-            value={inputValue}
-            onBlur={() => {
-              isInputFocusedRef.current = false;
-            }}
-            onChange={(e) => setInputValue(e.target.value)}
-            onFocus={() => {
-              isInputFocusedRef.current = true;
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleOpenInput();
-              }
-            }}
-            placeholder={t('core:action.search_apps_or_link', {
-              postProcess: 'capitalizeFirstChar',
-            })}
+          <Box
             sx={{
-              color: theme.palette.text.primary,
+              alignItems: 'center',
+              display: 'flex',
               flex: 1,
-              fontSize: '13.5px',
               minWidth: 0,
-              '& .MuiInputBase-input': {
-                py: '6px',
-              },
-              '& .MuiInputBase-input::placeholder': {
-                color: theme.palette.text.secondary,
-                opacity: 1,
-              },
+              position: 'relative',
             }}
-          />
+          >
+            {showStyledLinkPreview && (
+              <Box
+                aria-hidden
+                sx={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  inset: 0,
+                  overflow: 'hidden',
+                  pointerEvents: 'none',
+                  position: 'absolute',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <Box
+                  component="span"
+                  sx={{
+                    color: protocolColor,
+                    fontSize: '13.5px',
+                    transition: 'color 220ms ease',
+                  }}
+                >
+                  {protocolText}
+                </Box>
+                <Box
+                  component="span"
+                  sx={{
+                    color: remainderColor,
+                    fontSize: '13.5px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    transition: 'color 220ms ease',
+                  }}
+                >
+                  {remainderText}
+                </Box>
+              </Box>
+            )}
+            <InputBase
+              inputRef={inputElementRef}
+              value={inputValue}
+              onBlur={() => {
+                isInputFocusedRef.current = false;
+                setIsInputFocused(false);
+              }}
+              onChange={(e) => setInputValue(e.target.value)}
+              onFocus={() => {
+                isInputFocusedRef.current = true;
+                setIsInputFocused(true);
+                window.setTimeout(() => {
+                  inputElementRef.current?.select();
+                }, 0);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleOpenInput();
+                }
+              }}
+              placeholder={t('core:action.search_apps_or_link', {
+                postProcess: 'capitalizeFirstChar',
+              })}
+              sx={{
+                color: inputTextColor,
+                flex: 1,
+                fontSize: '13.5px',
+                minWidth: 0,
+                transition: 'color 220ms ease',
+                '& .MuiInputBase-input': {
+                  color: showStyledLinkPreview ? 'transparent' : 'inherit',
+                  py: '6px',
+                  transition: 'color 220ms ease',
+                  '::selection': {
+                    backgroundColor: selectionBackground,
+                    color: selectionColor,
+                  },
+                },
+                '& .MuiInputBase-input::placeholder': {
+                  color: placeholderColor,
+                  opacity: 1,
+                  transition: 'color 220ms ease',
+                },
+              }}
+            />
+          </Box>
           <ButtonBase
             onClick={handleOpenInput}
             sx={{
@@ -348,12 +439,11 @@ export function GlobalQortalNavBar({
               height: 26,
               justifyContent: 'center',
               transition:
-                'background-color 180ms ease, color 180ms ease, transform 220ms ease',
+                'background-color 180ms ease, color 180ms ease',
               width: 26,
               '&:hover': {
                 backgroundColor: buttonHoverBackground,
                 color: theme.palette.text.primary,
-                transform: 'translateY(-1px)',
               },
             }}
           >

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -173,6 +173,12 @@ export function GlobalQortalNavBar({
     theme.palette.mode === 'dark'
       ? 'rgba(176, 176, 176, 0.9)'
       : 'rgba(0, 0, 0, 0.56)';
+  const linkTextMetrics = {
+    fontSize: '13.5px',
+    fontWeight: 400,
+    letterSpacing: 'normal',
+    lineHeight: '20px',
+  } as const;
 
   return (
     <Box
@@ -361,8 +367,11 @@ export function GlobalQortalNavBar({
                   component="span"
                   sx={{
                     color: protocolColor,
-                    fontSize: '13.5px',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    height: '20px',
                     transition: 'color 220ms ease',
+                    ...linkTextMetrics,
                   }}
                 >
                   {protocolText}
@@ -370,11 +379,14 @@ export function GlobalQortalNavBar({
                 <Box
                   component="span"
                   sx={{
+                    alignItems: 'center',
                     color: remainderColor,
-                    fontSize: '13.5px',
+                    display: 'inline-flex',
+                    height: '20px',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     transition: 'color 220ms ease',
+                    ...linkTextMetrics,
                   }}
                 >
                   {remainderText}
@@ -408,13 +420,20 @@ export function GlobalQortalNavBar({
               sx={{
                 color: inputTextColor,
                 flex: 1,
-                fontSize: '13.5px',
                 minWidth: 0,
                 transition: 'color 220ms ease',
+                ...linkTextMetrics,
                 '& .MuiInputBase-input': {
+                  appearance: 'none',
+                  boxSizing: 'border-box',
                   color: showStyledLinkPreview ? 'transparent' : 'inherit',
-                  py: '6px',
+                  display: 'block',
+                  height: '20px',
+                  lineHeight: '20px',
+                  margin: 0,
+                  padding: 0,
                   transition: 'color 220ms ease',
+                  ...linkTextMetrics,
                   '::selection': {
                     backgroundColor: selectionBackground,
                     color: selectionColor,

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -86,8 +86,10 @@ export function GlobalQortalNavBar({
     const trimmed = inputValue.trim();
     if (!trimmed) return;
 
-    const normalized = normalizeQortalInput(trimmed);
-    const parsedLink = extractComponents(normalized);
+    const isExplicitQortalLink = /^qortal:\/\//i.test(trimmed);
+    const parsedLink = isExplicitQortalLink
+      ? extractComponents(normalizeQortalInput(trimmed))
+      : null;
 
     if (parsedLink) {
       const { service, name, identifier, path } = parsedLink;
@@ -117,8 +119,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.72)';
   const inputHoverBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(69, 82, 108, 0.94)'
-      : 'rgba(205, 223, 244, 0.92)';
+      ? 'rgba(62, 78, 108, 0.96)'
+      : 'rgba(194, 216, 242, 0.94)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(68, 71, 77, 0.94)'
@@ -144,8 +146,8 @@ export function GlobalQortalNavBar({
   const inputTextDefaultColor = theme.palette.text.secondary;
   const inputTextHoverColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(224, 224, 224, 0.92)'
-      : 'rgba(0, 0, 0, 0.72)';
+      ? 'rgba(236, 240, 246, 0.96)'
+      : 'rgba(0, 0, 0, 0.78)';
   const inputTextFocusColor = theme.palette.text.primary;
   const inputTextColor = isInputFocused
     ? inputTextFocusColor
@@ -165,12 +167,20 @@ export function GlobalQortalNavBar({
   const remainderText = protocolText ? inputValue.slice(protocolText.length) : '';
   const protocolColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(224, 224, 224, 0.92)'
-      : 'rgba(0, 0, 0, 0.74)';
+      ? isInputHovered
+        ? 'rgba(242, 246, 252, 0.98)'
+        : 'rgba(224, 224, 224, 0.92)'
+      : isInputHovered
+        ? 'rgba(0, 0, 0, 0.82)'
+        : 'rgba(0, 0, 0, 0.74)';
   const remainderColor =
     theme.palette.mode === 'dark'
-      ? 'rgba(176, 176, 176, 0.9)'
-      : 'rgba(0, 0, 0, 0.56)';
+      ? isInputHovered
+        ? 'rgba(218, 226, 238, 0.94)'
+        : 'rgba(176, 176, 176, 0.9)'
+      : isInputHovered
+        ? 'rgba(0, 0, 0, 0.66)'
+        : 'rgba(0, 0, 0, 0.56)';
   const linkTextMetrics = {
     fontSize: '13.5px',
     fontWeight: 400,
@@ -412,9 +422,7 @@ export function GlobalQortalNavBar({
                   handleOpenInput();
                 }
               }}
-              placeholder={t('core:action.search_apps_or_link', {
-                postProcess: 'capitalizeFirstChar',
-              })}
+              placeholder="Search Q-Apps or enter qortal://"
               sx={{
                 color: inputTextColor,
                 flex: 1,

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -117,8 +117,8 @@ export function GlobalQortalNavBar({
       : 'rgba(255, 255, 255, 0.72)';
   const inputHoverBackground =
     theme.palette.mode === 'dark'
-      ? 'rgba(65, 67, 73, 0.94)'
-      : 'rgba(255, 255, 255, 0.82)';
+      ? 'rgba(69, 82, 108, 0.94)'
+      : 'rgba(205, 223, 244, 0.92)';
   const inputFocusBackground =
     theme.palette.mode === 'dark'
       ? 'rgba(68, 71, 77, 0.94)'
@@ -132,9 +132,7 @@ export function GlobalQortalNavBar({
       ? 'rgba(255, 255, 255, 0.24)'
       : 'rgba(0, 0, 0, 0.2)';
   const inputHoverShadow =
-    theme.palette.mode === 'dark'
-      ? `0 0 0 1px rgba(94, 154, 255, 0.3), 0 0 0 3px rgba(94, 154, 255, 0.12)`
-      : `0 0 0 1px rgba(41, 121, 218, 0.28), 0 0 0 3px rgba(41, 121, 218, 0.1)`;
+    'none';
   const inputFocusShadow =
     theme.palette.mode === 'dark'
       ? 'none'

--- a/src/components/Desktop/GlobalQortalNavBar.tsx
+++ b/src/components/Desktop/GlobalQortalNavBar.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, ButtonBase, InputBase, useTheme } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
+import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
+import { useAtomValue } from 'jotai';
+import { useTranslation } from 'react-i18next';
+import { extractComponents } from '../Chat/MessageDisplay';
+import { navigationControllerAtom } from '../../atoms/global';
+import {
+  executeEvent,
+  subscribeToEvent,
+  unsubscribeFromEvent,
+} from '../../utils/events';
+import { QORTAL_PROTOCOL } from '../../constants/constants';
+import { APP_NAV_BAR_HEIGHT } from './CustomTitleBar';
+
+type GlobalQortalNavBarProps = {
+  desktopViewMode: string;
+};
+
+type SelectedTab = {
+  tabId: string;
+  name: string;
+  service: string;
+  identifier?: string;
+  path?: string;
+  refreshFunc?: (tabId?: string) => void;
+} | null;
+
+function normalizeQortalInput(value: string) {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return '';
+  if (/^qortal:\/\//i.test(trimmed)) return trimmed;
+  return `${QORTAL_PROTOCOL}${trimmed}`;
+}
+
+export function GlobalQortalNavBar({
+  desktopViewMode,
+}: GlobalQortalNavBarProps) {
+  const theme = useTheme();
+  const navigationController = useAtomValue(navigationControllerAtom);
+  const { t } = useTranslation(['core']);
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>(null);
+  const [inputValue, setInputValue] = useState('');
+  const isInputFocusedRef = useRef(false);
+
+  const setTabsToNav = useCallback((e: CustomEvent) => {
+    const nextSelectedTab = e.detail?.data?.selectedTab;
+    setSelectedTab(nextSelectedTab ? { ...nextSelectedTab } : null);
+  }, []);
+
+  useEffect(() => {
+    subscribeToEvent('setTabsToNav', setTabsToNav);
+
+    return () => {
+      unsubscribeFromEvent('setTabsToNav', setTabsToNav);
+    };
+  }, [setTabsToNav]);
+
+  const currentNavigation = selectedTab?.tabId
+    ? navigationController?.[selectedTab.tabId]
+    : null;
+
+  const currentLink = useMemo(() => {
+    return currentNavigation?.currentLink || '';
+  }, [currentNavigation]);
+
+  useEffect(() => {
+    if (isInputFocusedRef.current) return;
+    if (desktopViewMode === 'apps' && currentLink) {
+      setInputValue(currentLink);
+      return;
+    }
+    if (desktopViewMode !== 'apps') {
+      setInputValue('');
+    }
+  }, [currentLink, desktopViewMode]);
+
+  const handleOpenInput = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    const normalized = normalizeQortalInput(trimmed);
+    const parsedLink = extractComponents(normalized);
+
+    if (parsedLink) {
+      const { service, name, identifier, path } = parsedLink;
+      executeEvent('addTab', { data: { service, name, identifier, path } });
+      executeEvent('open-apps-mode', {});
+      return;
+    }
+
+    executeEvent('openAppsLibrarySearch', {
+      data: {
+        query: trimmed,
+      },
+    });
+    executeEvent('open-apps-mode', {});
+  }, [inputValue]);
+
+  const canGoBack = !!selectedTab?.tabId && !!currentNavigation?.hasBack;
+  const canGoForward = !!selectedTab?.tabId && !!currentNavigation?.hasForward;
+  const canRefresh = !!selectedTab?.tabId && desktopViewMode === 'apps';
+  const chromeBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(39, 40, 44, 0.96)'
+      : 'rgba(206, 209, 216, 0.96)';
+  const inputBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(58, 60, 65, 0.88)'
+      : 'rgba(255, 255, 255, 0.72)';
+  const inputHoverBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(65, 67, 73, 0.94)'
+      : 'rgba(255, 255, 255, 0.82)';
+  const inputFocusBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(70, 73, 79, 0.96)'
+      : 'rgba(255, 255, 255, 0.9)';
+  const hoverBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.16)'
+      : 'rgba(0, 0, 0, 0.14)';
+  const focusBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.24)'
+      : 'rgba(0, 0, 0, 0.2)';
+  const inputHoverShadow =
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgba(255, 255, 255, 0.03), 0 8px 18px rgba(0, 0, 0, 0.14)'
+      : '0 0 0 1px rgba(255, 255, 255, 0.08), 0 8px 18px rgba(120, 127, 140, 0.12)';
+  const inputFocusShadow =
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgba(255, 255, 255, 0.06), 0 10px 24px rgba(0, 0, 0, 0.2)'
+      : '0 0 0 1px rgba(255, 255, 255, 0.12), 0 10px 24px rgba(120, 127, 140, 0.16)';
+  const buttonHoverBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.06)'
+      : 'rgba(0, 0, 0, 0.05)';
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        backdropFilter: 'blur(10px)',
+        backgroundColor: chromeBackground,
+        borderBottom: `1px solid ${theme.palette.border.subtle}`,
+        display: 'flex',
+        height: `${APP_NAV_BAR_HEIGHT}px`,
+        width: '100%',
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: 1.25,
+          height: '100%',
+          maxWidth: '100%',
+          pl: { xs: 1.5, sm: 2, md: 3 },
+          pr: { xs: 1.5, sm: 2, md: 2.5 },
+          width: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            flexShrink: 0,
+            gap: 0.5,
+            pr: 1.25,
+            position: 'relative',
+            '&::after': {
+              backgroundColor: theme.palette.border.subtle,
+              content: '""',
+              height: 20,
+              position: 'absolute',
+              right: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '1px',
+            },
+          }}
+        >
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              executeEvent(`navigateBackApp-${selectedTab.tabId}`, {});
+            }}
+            disabled={!canGoBack}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canGoBack ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowBackIosNewRoundedIcon sx={{ fontSize: 15 }} />
+          </ButtonBase>
+
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              executeEvent(`navigateForwardApp-${selectedTab.tabId}`, {});
+            }}
+            disabled={!canGoForward}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canGoForward ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowForwardIosRoundedIcon sx={{ fontSize: 15 }} />
+          </ButtonBase>
+
+          <ButtonBase
+            onClick={() => {
+              if (!selectedTab?.tabId) return;
+              if (selectedTab?.refreshFunc) {
+                selectedTab.refreshFunc(selectedTab?.tabId);
+                return;
+              }
+              executeEvent('refreshApp', {
+                tabId: selectedTab.tabId,
+              });
+            }}
+            disabled={!canRefresh}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '9px',
+              color: theme.palette.text.primary,
+              display: 'flex',
+              height: 32,
+              justifyContent: 'center',
+              opacity: canRefresh ? 1 : 0.32,
+              transition:
+                'background-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 220ms ease',
+              width: 32,
+              '&:hover:not(.Mui-disabled)': {
+                backgroundColor: buttonHoverBackground,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <RefreshIcon sx={{ fontSize: 18 }} />
+          </ButtonBase>
+        </Box>
+
+        <Box
+          sx={{
+            alignItems: 'center',
+            backgroundColor: inputBackground,
+            border: `1px solid ${theme.palette.border.subtle}`,
+            borderRadius: '12px',
+            display: 'flex',
+            flex: 1,
+            gap: 1,
+            height: 34,
+            minWidth: 0,
+            px: 1.5,
+            boxShadow: 'none',
+            transition:
+              'background-color 240ms ease, border-color 240ms ease, box-shadow 280ms ease, transform 280ms ease',
+            '&:hover': {
+              backgroundColor: inputHoverBackground,
+              borderColor: hoverBorderColor,
+              boxShadow: inputHoverShadow,
+              transform: 'translateY(-1px)',
+            },
+            '&:focus-within': {
+              backgroundColor: inputFocusBackground,
+              borderColor: focusBorderColor,
+              boxShadow: inputFocusShadow,
+              transform: 'translateY(-1px)',
+            },
+          }}
+        >
+          <SearchIcon
+            sx={{
+              color: theme.palette.text.secondary,
+              fontSize: 17,
+            }}
+          />
+          <InputBase
+            value={inputValue}
+            onBlur={() => {
+              isInputFocusedRef.current = false;
+            }}
+            onChange={(e) => setInputValue(e.target.value)}
+            onFocus={() => {
+              isInputFocusedRef.current = true;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleOpenInput();
+              }
+            }}
+            placeholder={t('core:action.search_apps_or_link', {
+              postProcess: 'capitalizeFirstChar',
+            })}
+            sx={{
+              color: theme.palette.text.primary,
+              flex: 1,
+              fontSize: '13.5px',
+              minWidth: 0,
+              '& .MuiInputBase-input': {
+                py: '6px',
+              },
+              '& .MuiInputBase-input::placeholder': {
+                color: theme.palette.text.secondary,
+                opacity: 1,
+              },
+            }}
+          />
+          <ButtonBase
+            onClick={handleOpenInput}
+            sx={{
+              alignItems: 'center',
+              borderRadius: '8px',
+              color: theme.palette.text.secondary,
+              display: 'flex',
+              flexShrink: 0,
+              height: 26,
+              justifyContent: 'center',
+              transition:
+                'background-color 180ms ease, color 180ms ease, transform 220ms ease',
+              width: 26,
+              '&:hover': {
+                backgroundColor: buttonHoverBackground,
+                color: theme.palette.text.primary,
+                transform: 'translateY(-1px)',
+              },
+            }}
+          >
+            <ArrowOutwardIcon sx={{ fontSize: 17 }} />
+          </ButtonBase>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Group/GlobalChatWidget.tsx
+++ b/src/components/Group/GlobalChatWidget.tsx
@@ -46,7 +46,7 @@ import { MiniDirectThread } from '../Chat/MiniDirectThread';
 import { MiniGroupThread } from '../Chat/MiniGroupThread';
 import { useNameSearch } from '../../hooks/useNameSearch';
 import { validateAddress } from '../../utils/validateAddress';
-import { appHeighOffset, appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffset, appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 export type ChatWidgetTab = 'messages' | 'groups';
 
@@ -114,7 +114,7 @@ export function GlobalChatWidget({
     if (typeof window === 'undefined')
       return { x: 0, width: 380, height: 560 };
     const w = window.innerWidth;
-    const h = window.innerHeight - appHeighOffset;
+    const h = window.innerHeight - appChromeOffset;
     const maxW = Math.min(WIDGET_MAX_WIDTH, w - 48);
     const maxH = Math.min(
       WIDGET_MAX_HEIGHT,
@@ -140,7 +140,7 @@ export function GlobalChatWidget({
 
   const [windowSize, setWindowSize] = useState(() =>
     typeof window !== 'undefined'
-      ? { w: window.innerWidth, h: window.innerHeight - appHeighOffset }
+      ? { w: window.innerWidth, h: window.innerHeight - appChromeOffset }
       : { w: 800, h: 600 }
   );
   const [bottomX, setBottomX] = useState(initialBounds.x);
@@ -221,7 +221,7 @@ export function GlobalChatWidget({
 
   useEffect(() => {
     const onResize = () =>
-      setWindowSize({ w: window.innerWidth, h: window.innerHeight - appHeighOffset });
+      setWindowSize({ w: window.innerWidth, h: window.innerHeight - appChromeOffset });
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
@@ -231,7 +231,7 @@ export function GlobalChatWidget({
     if (!storedBounds || hasAppliedStoredRef.current) return;
     hasAppliedStoredRef.current = true;
     const w = window.innerWidth;
-    const h = window.innerHeight - appHeighOffset;
+    const h = window.innerHeight - appChromeOffset;
     const maxW = Math.min(WIDGET_MAX_WIDTH, w - 48);
     const maxH = Math.min(
       WIDGET_MAX_HEIGHT,
@@ -618,7 +618,7 @@ export function GlobalChatWidget({
                   height: widgetHeight,
                   minHeight: WIDGET_MIN_HEIGHT,
                   maxHeight:
-                    `min(800px, calc(100vh - ${appHeighOffsetPx} - 120px))`,
+                    `min(800px, calc(100vh - ${appChromeOffsetPx} - 120px))`,
                   overflow: 'hidden',
                   visibility: 'visible',
                   opacity: 1,

--- a/src/components/Group/Group.styles.ts
+++ b/src/components/Group/Group.styles.ts
@@ -1,7 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/system';
 import { AuthenticatedContainerInnerRight } from '../../styles/App-styles';
-import { appHeighOffset } from '../Desktop/CustomTitleBar';
+import { appChromeOffset } from '../Desktop/CustomTitleBar';
 
 /**
  * Group layout styled components using MUI's styled API.
@@ -55,7 +55,7 @@ export const AdminRowBox = styled(Box)({
 export const ChatContentBox = styled(Box)({
   display: 'flex',
   flexGrow: 1,
-  height: `calc(100vh - ${70 + appHeighOffset}px)`,
+  height: `calc(100vh - ${70 + appChromeOffset}px)`,
   position: 'relative',
 });
 
@@ -72,7 +72,7 @@ export const NotPartGroupDiv = styled('div')({
   alignItems: 'flex-start',
   display: 'flex',
   flexDirection: 'column',
-  height: `calc(100vh - ${70 + appHeighOffset}px)`,
+  height: `calc(100vh - ${70 + appChromeOffset}px)`,
   overflow: 'auto',
   padding: '20px',
   width: '100%',

--- a/src/components/Group/WalletsAppWrapper.tsx
+++ b/src/components/Group/WalletsAppWrapper.tsx
@@ -13,7 +13,7 @@ import { NavBack } from '../../assets/Icons/NavBack.tsx';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { appHeighOffsetPx } from '../Desktop/CustomTitleBar';
+import { appChromeOffsetPx } from '../Desktop/CustomTitleBar';
 
 export const WalletsAppWrapper = () => {
   const { t } = useTranslation([
@@ -73,7 +73,7 @@ export const WalletsAppWrapper = () => {
             borderTopRightRadius: '10px',
             bottom: 0,
             boxShadow: 4,
-            height: `calc(100vh - ${appHeighOffsetPx})`,
+            height: `calc(100vh - ${appChromeOffsetPx})`,
             overflow: 'hidden',
             position: 'fixed',
             right: 0,

--- a/src/hooks/useQortalMessageListener.tsx
+++ b/src/hooks/useQortalMessageListener.tsx
@@ -11,10 +11,12 @@ import { mimeToExtensionMap } from '../utils/memeTypes';
 import FileSaver from 'file-saver';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
+  QORTAL_PROTOCOL,
   TIME_HOURS_1_IN_MILLISECONDS,
   TIME_MINUTES_30_IN_MILLISECONDS,
   TIME_SECONDS_30_IN_MILLISECONDS,
 } from '../constants/constants';
+import { buildQortalResourceLink } from '../utils/qortalLink';
 
 export const saveFileInChunks = async (
   blob: Blob,
@@ -535,6 +537,7 @@ export const useQortalMessageListener = (
   isDevMode,
   appName,
   appService,
+  appIdentifier,
   skipAuth
 ) => {
   const [path, setPath] = useState('');
@@ -553,15 +556,38 @@ export const useQortalMessageListener = (
   useEffect(() => {
     if (tabId && !isNaN(history?.currentIndex)) {
       setHasSettingsChangedAtom((prev) => {
+        // Preserve identifier in qortal:// links when present because QDN
+        // targeting depends on it. Links without identifier must still work.
         return {
           ...prev,
           [tabId]: {
             hasBack: history?.currentIndex > 0,
+            hasForward:
+              history?.currentIndex >= 0 &&
+              history?.currentIndex <
+                (history?.customQDNHistoryPaths?.length || 0) - 1,
+            currentLink:
+              appService && appName
+                ? buildQortalResourceLink({
+                    service: appService,
+                    name: appName,
+                    path: path || '',
+                    identifier: appIdentifier,
+                  })
+                : '',
           },
         };
       });
     }
-  }, [history?.currentIndex, tabId]);
+  }, [
+    appIdentifier,
+    appName,
+    appService,
+    history?.currentIndex,
+    history?.customQDNHistoryPaths,
+    path,
+    tabId,
+  ]);
 
   const changeCurrentIndex = useCallback((value) => {
     setHistory((prev) => {

--- a/src/qortal/get.ts
+++ b/src/qortal/get.ts
@@ -459,6 +459,11 @@ const handleMessage = (event) => {
 
 window.addEventListener('message', handleMessage);
 
+const getPermissionSourceMeta = (appInfo, isFromExtension) => ({
+  sourceLabel: appInfo?.name || undefined,
+  sourceKind: appInfo?.name ? 'Q-App' : isFromExtension ? 'Extension' : 'Application',
+});
+
 async function getUserPermission(payload, isFromExtension) {
   return new Promise((resolve) => {
     const requestId = `qortalRequest_${Date.now()}`;
@@ -530,12 +535,14 @@ export const getUserAccount = async ({
           text1: i18n.t('question:permission.authenticate', {
             postProcess: 'capitalizeFirstChar',
           }),
+          requestType: 'GET_USER_ACCOUNT',
           checkbox1: {
             value: false,
             label: i18n.t('question:always_authenticate', {
               postProcess: 'capitalizeFirstChar',
             }),
           },
+          ...getPermissionSourceMeta(appInfo, isFromExtension),
         },
         isFromExtension
       );
@@ -634,6 +641,7 @@ export const sessionPermissions = async (data, isFromExtension, appInfo) => {
           appName: appInfo.name,
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SESSION_PERMISSIONS',
         text2: i18n.t('question:permission.session_permissions_description', {
           defaultValue:
             'The following permissions will be automatically granted for this session:',
@@ -656,6 +664,7 @@ export const sessionPermissions = async (data, isFromExtension, appInfo) => {
           postProcess: 'capitalizeFirstChar',
         }),
         isSessionPermission: true,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -1672,11 +1681,13 @@ export const publishQDNResource = async (
         text1: i18n.t('question:permission.publish_qdn', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'PUBLISH_QDN_RESOURCE',
         text2: `service: ${service}`,
         text3: `identifier: ${identifier || null}`,
         text4: `name: ${registeredName}`,
         fee: fee.fee,
         ...handleDynamicValues,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -1984,6 +1995,7 @@ export const publishMultipleQDNResources = async (
         text1: i18n.t('question:permission.publish_qdn', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'PUBLISH_MULTIPLE_QDN_RESOURCES',
         html: `
     <div style="max-height: 30vh; overflow-y: auto;">
     <style>
@@ -2043,6 +2055,7 @@ export const publishMultipleQDNResources = async (
       `,
         fee: +fee.fee * resources.length,
         ...handleDynamicValues,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3456,6 +3469,7 @@ export const getUserWallet = async (data, isFromExtension, appInfo) => {
         text1: i18n.t('question:permission.get_wallet_info', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3463,6 +3477,7 @@ export const getUserWallet = async (data, isFromExtension, appInfo) => {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3608,12 +3623,14 @@ export const getWalletBalance = async (
           coin: data.coin, // TODO highlight coin in the modal
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_WALLET_BALANCE',
         checkbox1: {
           value: false,
           label: i18n.t('question:always_retrieve_balance', {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3863,6 +3880,7 @@ export const getUserWalletInfo = async (data, isFromExtension, appInfo) => {
         text1: i18n.t('question:permission.get_wallet_info', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET_INFO',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3870,6 +3888,7 @@ export const getUserWalletInfo = async (data, isFromExtension, appInfo) => {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3983,6 +4002,7 @@ export const getUserWalletTransactions = async (
         text1: i18n.t('question:permission.get_wallet_transactions', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET_TRANSACTIONS',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3990,6 +4010,7 @@ export const getUserWalletTransactions = async (
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -5090,6 +5111,7 @@ export const sendCoin = async (data, isFromExtension) => {
         text1: i18n.t('question:permission.send_coins', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SEND_COIN',
         text2: i18n.t('question:to_recipient', {
           recipient: recipient,
           postProcess: 'capitalizeFirstChar',
@@ -5097,6 +5119,7 @@ export const sendCoin = async (data, isFromExtension) => {
         highlightedText: `${amount} ${checkCoin}`,
         fee: fee,
         confirmCheckbox: true,
+        ...getPermissionSourceMeta(undefined, isFromExtension),
       },
       isFromExtension
     );
@@ -5147,12 +5170,14 @@ export const sendCoin = async (data, isFromExtension) => {
         text1: i18n.t('question:permission.send_coins', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SEND_COIN',
         text2: i18n.t('question:to_recipient', {
           recipient: recipient,
           postProcess: 'capitalizeFirstChar',
         }),
         highlightedText: `${amount} ${checkCoin}`,
         foreignFee: `${fee} BTC`,
+        ...getPermissionSourceMeta(undefined, isFromExtension),
       },
       isFromExtension
     );
@@ -6357,12 +6382,14 @@ export const signTransaction = async (data, isFromExtension) => {
         : i18n.t('question:permission.sign_transaction', {
             postProcess: 'capitalizeFirstChar',
           }),
+      requestType: 'SIGN_TRANSACTION',
       highlightedText: i18n.t(
         'question:message.generic.read_transaction_carefully',
         { postProcess: 'capitalizeFirstChar' }
       ),
       text2: `Tx type: ${decodedData.type}`,
       json: decodedData,
+      ...getPermissionSourceMeta(undefined, isFromExtension),
     },
     isFromExtension
   );

--- a/src/utils/qortalLink/index.ts
+++ b/src/utils/qortalLink/index.ts
@@ -1,3 +1,5 @@
+import { QORTAL_PROTOCOL } from '../../constants/constants';
+
 export function convertQortalLinks(inputHtml: string) {
   // Regular expression to match 'qortal://...' URLs.
   // This will stop at the first whitespace, comma, or HTML tag
@@ -9,4 +11,26 @@ export function convertQortalLinks(inputHtml: string) {
   });
 
   return outputHtml;
+}
+
+type QortalResourceLinkInput = {
+  service?: string;
+  name?: string;
+  path?: string;
+  identifier?: string;
+};
+
+export function buildQortalResourceLink({
+  service,
+  name,
+  path = '',
+  identifier,
+}: QortalResourceLinkInput): string {
+  const encodedName = (name || '').replace(/ /g, '%20');
+  const normalizedPath = path || '';
+  const identifierSuffix = identifier
+    ? `${normalizedPath.includes('?') ? '&' : '?'}identifier=${encodeURIComponent(identifier)}`
+    : '';
+
+  return `${QORTAL_PROTOCOL}${service}/${encodedName}${normalizedPath}${identifierSuffix}`;
 }


### PR DESCRIPTION
**Before:**
<img width="490" height="322" alt="Screenshot 2026-04-12 045626" src="https://github.com/user-attachments/assets/aa31d287-eb45-44e8-8b17-5b0c662fb0b7" />

**After:**
<img width="572" height="721" alt="Screenshot 2026-04-13 012512" src="https://github.com/user-attachments/assets/855b54fa-e192-4f29-a1fd-4442763bf25a" />

This PR improves the permission modal UI to make requests clearer and easier to understand for users.

What’s included:

- Human-readable titles for ALL request types
- Cleaner summaries based on actual request data
- Improved layout for complex requests like multi-publish
- Raw transaction payload is still visible but visually toned down
- Added [local preview mode for testing](http://127.0.0.1:5173/?permission-preview=1) 

Scope:

- Covers all permission request types (40+ total)
- Core/high-impact requests (authentication, payments, publishing, signing) have custom, fully tailored summaries
- Remaining request types use a consistent fallback system with human-readable titles (e.g. “ban user”, “create group”, etc.) instead of generic wording

Important:

- No permission logic or behavior was changed
- UI-only improvement
- Existing request handling plugs into this presentation layer

Testing:

You can preview all request types locally:
http://127.0.0.1:5173/?permission-preview=1