### PR TITLE
Permission modal UI redesign + local preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,7 @@ import {
   CUSTOM_TITLE_BAR_HEIGHT,
 } from './components/Desktop/CustomTitleBar';
 import { roundUpToDecimals } from './utils/numberFunctions.ts';
+import { QortalPermissionPreview } from './components/App/QortalPermissionPreview.tsx';
 
 // Re-export for consumers that still import from App
 export type { extStates } from './types/app';
@@ -127,6 +128,9 @@ export {
 export { isMainWindow } from './constants/app';
 
 function App() {
+  const permissionPreviewMode =
+    import.meta.env.DEV &&
+    new URLSearchParams(window.location.search).get('permission-preview') === '1';
   const [extState, setExtstate] = useAtom(extStateAtom);
   const [desktopViewMode, setDesktopViewMode] = useState('home');
   const [rawWallet, setRawWallet] = useAtom(rawWalletAtom);
@@ -1336,6 +1340,10 @@ function App() {
           onBackupWallet,
         }
       : null;
+
+  if (permissionPreviewMode) {
+    return <QortalPermissionPreview />;
+  }
 
   return (
     <AppContainer

--- a/src/components/App/QortalPermissionPreview.tsx
+++ b/src/components/App/QortalPermissionPreview.tsx
@@ -1,0 +1,305 @@
+import { Box, Chip, FormControlLabel, MenuItem, Select, Switch, Typography, alpha, useTheme } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { QortalPermissionCard } from './QortalRequestExtensionDialog';
+import {
+  MODAL_REQUEST_TYPES,
+  type MessageQortalRequestExtension,
+} from './qortalPermissionPresentation';
+
+const PRIORITY_REQUESTS = [
+  'GET_USER_ACCOUNT',
+  'SESSION_PERMISSIONS',
+  'PUBLISH_QDN_RESOURCE',
+  'PUBLISH_MULTIPLE_QDN_RESOURCES',
+  'SEND_COIN',
+  'SIGN_TRANSACTION',
+];
+
+const orderedRequestTypes = [
+  ...PRIORITY_REQUESTS,
+  ...MODAL_REQUEST_TYPES.filter((requestType) => !PRIORITY_REQUESTS.includes(requestType)),
+];
+
+const createPreviewMessage = (
+  requestType: string,
+  includeSource: boolean,
+  includeRemember: boolean,
+  countdownDuration: number
+): MessageQortalRequestExtension => {
+  const baseMessage: MessageQortalRequestExtension = {
+    requestType,
+    countdownDuration,
+    sourceKind: 'Q-App',
+    sourceLabel: includeSource ? 'Q-Tube' : undefined,
+    technicalDetails: [{ rows: [{ label: 'Request type', value: requestType }] }],
+  };
+
+  if (includeRemember) {
+    baseMessage.checkbox1 = {
+      label: 'Always allow this automatically',
+      value: false,
+    };
+  }
+
+  switch (requestType) {
+    case 'GET_USER_ACCOUNT':
+      return {
+        ...baseMessage,
+        summaryBody:
+          'This confirms your Qortal identity for the application. It does not send a payment or publish data.',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Granted account field', value: 'Primary account identity' },
+            ],
+          },
+        ],
+      };
+    case 'SESSION_PERMISSIONS':
+      return {
+        ...baseMessage,
+        confirmCheckbox: true,
+        confirmCheckboxLabel: 'I trust this app and understand these permissions will auto-execute',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Requested permissions', value: 'GET_USER_ACCOUNT, PUBLISH_QDN_RESOURCE, SIGN_TRANSACTION' },
+              { label: 'Scope', value: 'Current session only' },
+            ],
+          },
+        ],
+      };
+    case 'PUBLISH_QDN_RESOURCE':
+      return {
+        ...baseMessage,
+        text2: 'service: DOCUMENT',
+        text3: 'identifier: grp-42-thread-abc123',
+        text4: 'name: q-tube',
+        fee: '0.10000000',
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Service', value: 'DOCUMENT' },
+              { label: 'Identifier', value: 'grp-42-thread-abc123' },
+              { label: 'Name', value: 'q-tube' },
+            ],
+          },
+        ],
+      };
+    case 'PUBLISH_MULTIPLE_QDN_RESOURCES':
+      return {
+        ...baseMessage,
+        fee: '0.20000000',
+        html: `
+          <div class="resource-container">
+            <div class="resource-detail"><span>Service:</span> IMAGE</div>
+            <div class="resource-detail"><span>Identifier:</span> grp-q-manager_1_group_42_abcd</div>
+            <div class="resource-detail"><span>Name:</span> q-tube</div>
+          </div>
+          <div class="resource-container">
+            <div class="resource-detail"><span>Service:</span> DOCUMENT_PRIVATE</div>
+            <div class="resource-detail"><span>Identifier:</span> episode-notes-42</div>
+            <div class="resource-detail"><span>Name:</span> q-tube</div>
+          </div>
+        `,
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { value: 'Resource 1' },
+              { label: 'Service', value: 'IMAGE' },
+              { label: 'Identifier', value: 'grp-q-manager_1_group_42_abcd' },
+              { label: 'Name', value: 'q-tube' },
+              { value: 'Resource 2' },
+              { label: 'Service', value: 'DOCUMENT_PRIVATE' },
+              { label: 'Identifier', value: 'episode-notes-42' },
+              { label: 'Name', value: 'q-tube' },
+            ],
+          },
+        ],
+      };
+    case 'SEND_COIN':
+      return {
+        ...baseMessage,
+        text2: 'to: Qabc123receiver',
+        highlightedText: '5 QORT',
+        fee: '0.00100000',
+      };
+    case 'SIGN_TRANSACTION':
+      return {
+        ...baseMessage,
+        summaryBody: 'This app wants your account to sign a transaction. Review the key facts before accepting.',
+        json: {
+          type: 'Payment',
+          recipient: 'Qxyz987destination',
+          amount: '5 QORT',
+        },
+      };
+    case 'ADD_FOREIGN_SERVER':
+      return {
+        ...baseMessage,
+        technicalDetails: [
+          {
+            rows: [
+              { label: 'Request type', value: requestType },
+              { label: 'Server host', value: 'api.qortalhub.net' },
+              { label: 'Server port', value: '12391' },
+              { label: 'Protocol', value: 'https' },
+            ],
+          },
+        ],
+      };
+    default:
+      return {
+        ...baseMessage,
+        technicalDetails: [
+          {
+            rows: [{ label: 'Request type', value: requestType }],
+          },
+        ],
+      };
+  }
+};
+
+export function QortalPermissionPreview() {
+  const theme = useTheme();
+  const [requestType, setRequestType] = useState<string>('GET_USER_ACCOUNT');
+  const [includeSource, setIncludeSource] = useState(true);
+  const [includeRemember, setIncludeRemember] = useState(true);
+  const [countdownDuration, setCountdownDuration] = useState(60);
+  const [confirmRequestRead, setConfirmRequestRead] = useState(false);
+  const [previewKey, setPreviewKey] = useState(0);
+
+  const message = useMemo(
+    () => createPreviewMessage(requestType, includeSource, includeRemember, countdownDuration),
+    [requestType, includeSource, includeRemember, countdownDuration]
+  );
+
+  return (
+    <Box
+      sx={{
+        background: theme.palette.mode === 'dark'
+          ? 'linear-gradient(180deg, #17191d 0%, #111317 100%)'
+          : 'linear-gradient(180deg, #f4f6f8 0%, #ecf0f3 100%)',
+        display: 'grid',
+        gap: '24px',
+        gridTemplateColumns: { md: '320px minmax(0, 1fr)' },
+        minHeight: '100vh',
+        padding: '24px',
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: alpha(theme.palette.background.paper, 0.84),
+          border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+          borderRadius: '20px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '18px',
+          padding: '20px',
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Chip label="Dev-only preview" sx={{ alignSelf: 'flex-start' }} />
+          <Typography sx={{ fontSize: '24px', fontWeight: 700 }}>Qortal permission modal preview</Typography>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '14px', lineHeight: 1.5 }}>
+            This page renders the same permission card used by the real modal so common flows and edge cases can be reviewed locally without triggering real requests.
+          </Typography>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '12px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Request type
+          </Typography>
+          <Select
+            value={requestType}
+            onChange={(event) => {
+              setRequestType(event.target.value);
+              setConfirmRequestRead(false);
+              setPreviewKey((value) => value + 1);
+            }}
+            size="small"
+          >
+            {orderedRequestTypes.map((item) => (
+              <MenuItem key={item} value={item}>
+                {item}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={includeSource}
+              onChange={(event) => {
+                setIncludeSource(event.target.checked);
+                setPreviewKey((value) => value + 1);
+              }}
+            />
+          }
+          label="Show source identity"
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={includeRemember}
+              onChange={(event) => {
+                setIncludeRemember(event.target.checked);
+                setPreviewKey((value) => value + 1);
+              }}
+            />
+          }
+          label="Show remember option"
+        />
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '12px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Countdown state
+          </Typography>
+          <Select
+            value={countdownDuration}
+            onChange={(event) => {
+              setCountdownDuration(Number(event.target.value));
+              setPreviewKey((value) => value + 1);
+            }}
+            size="small"
+          >
+            <MenuItem value={60}>60 seconds</MenuItem>
+            <MenuItem value={15}>15 seconds</MenuItem>
+            <MenuItem value={5}>5 seconds</MenuItem>
+          </Select>
+        </Box>
+
+        <Typography sx={{ color: theme.palette.text.secondary, fontSize: '13px', lineHeight: 1.5 }}>
+          Priority flows are listed first: authentication, session permissions, and QDN publishing. The remaining items cover every request type that currently uses the permission modal flow.
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'center',
+          minHeight: '70vh',
+          padding: { xs: 0, md: '12px' },
+        }}
+      >
+        <QortalPermissionCard
+          key={`${requestType}-${includeSource}-${includeRemember}-${countdownDuration}-${previewKey}`}
+          message={message}
+          confirmRequestRead={confirmRequestRead}
+          onConfirmRequestReadChange={setConfirmRequestRead}
+          onCheckbox1Change={() => undefined}
+          onAccept={() => undefined}
+          onCancel={() => undefined}
+          onCountdownComplete={() => undefined}
+          countdownSeconds={countdownDuration}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/App/QortalPermissionPreview.tsx
+++ b/src/components/App/QortalPermissionPreview.tsx
@@ -46,7 +46,7 @@ const createPreviewMessage = (
       return {
         ...baseMessage,
         summaryBody:
-          'This confirms your Qortal identity for the application. It does not send a payment or publish data.',
+          'This confirms your Qortal identity for the application.\nThis action does not send a payment or publish data.',
         technicalDetails: [
           {
             rows: [

--- a/src/components/App/QortalRequestExtensionDialog.tsx
+++ b/src/components/App/QortalRequestExtensionDialog.tsx
@@ -50,6 +50,10 @@ type PermissionCardProps = {
   onCancel: () => void;
   onCountdownComplete: () => void;
   countdownSeconds?: number;
+  showCountdown?: boolean;
+  acceptLabel?: string;
+  declineLabel?: string;
+  hideDecline?: boolean;
 };
 
 const renderDetailSection = (
@@ -166,6 +170,10 @@ export function QortalPermissionCard({
   onCancel,
   onCountdownComplete,
   countdownSeconds,
+  showCountdown = true,
+  acceptLabel,
+  declineLabel,
+  hideDecline = false,
 }: PermissionCardProps) {
   const theme = useTheme();
   const { t } = useTranslation(['core']);
@@ -220,7 +228,7 @@ export function QortalPermissionCard({
             borderBottom: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
           }}
         >
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px', minWidth: 0 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px', minWidth: 0 }}>
             <Box
               sx={{
                 alignItems: 'center',
@@ -249,6 +257,7 @@ export function QortalPermissionCard({
                 fontWeight: 700,
                 letterSpacing: '-0.02em',
                 lineHeight: 1.12,
+                marginTop: '4px',
               }}
             >
               {presentation.title}
@@ -259,41 +268,44 @@ export function QortalPermissionCard({
                 fontSize: '14px',
                 lineHeight: 1.5,
                 maxWidth: '440px',
+                whiteSpace: 'pre-line',
               }}
             >
               {presentation.body}
             </Typography>
           </Box>
-          <Box
-            sx={{
-              alignItems: 'center',
-              backgroundColor:
-                theme.palette.mode === 'dark'
-                  ? alpha('#0e141c', 0.95)
-                  : alpha('#f2f5f8', 0.98),
-              border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.14)}`,
-              borderRadius: '999px',
-              display: 'flex',
-              justifyContent: 'center',
-              minWidth: '74px',
-              padding: '6px 10px',
-            }}
-          >
-            <CountdownCircleTimer
-              isPlaying
-              duration={duration}
-              colors={['#2D7FF9', '#E8A13A', '#C45151', '#C45151']}
-              colorsTime={[Math.max(duration * 0.4, 10), Math.max(duration * 0.2, 5), 3, 0]}
-              onComplete={onCountdownComplete}
-              size={42}
-              strokeWidth={4}
-              trailColor={alpha(theme.palette.common.white, 0.12)}
+          {showCountdown ? (
+            <Box
+              sx={{
+                alignItems: 'center',
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#0e141c', 0.95)
+                    : alpha('#f2f5f8', 0.98),
+                border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.14)}`,
+                borderRadius: '999px',
+                display: 'flex',
+                justifyContent: 'center',
+                minWidth: '74px',
+                padding: '6px 10px',
+              }}
             >
-              {({ remainingTime }) => (
-                <TextP sx={{ fontSize: '13px', fontWeight: 700 }}>{remainingTime}</TextP>
-              )}
-            </CountdownCircleTimer>
-          </Box>
+              <CountdownCircleTimer
+                isPlaying
+                duration={duration}
+                colors={['#2D7FF9', '#E8A13A', '#C45151', '#C45151']}
+                colorsTime={[Math.max(duration * 0.4, 10), Math.max(duration * 0.2, 5), 3, 0]}
+                onComplete={onCountdownComplete}
+                size={42}
+                strokeWidth={4}
+                trailColor={alpha(theme.palette.common.white, 0.12)}
+              >
+                {({ remainingTime }) => (
+                  <TextP sx={{ fontSize: '13px', fontWeight: 700 }}>{remainingTime}</TextP>
+                )}
+              </CountdownCircleTimer>
+            </Box>
+          ) : null}
         </Box>
 
         <Spacer height="22px" />
@@ -571,43 +583,45 @@ export function QortalPermissionCard({
             alignItems: 'center',
             display: 'flex',
             gap: '12px',
-            justifyContent: 'flex-end',
+            justifyContent: hideDecline ? 'flex-end' : 'space-between',
             width: '100%',
           }}
         >
-          <CustomButtonAccept
-            customColor={theme.palette.text.primary}
-            customBgColor={
-              theme.palette.mode === 'dark'
-                ? alpha('#171d27', 0.96)
-                : alpha('#eef3f8', 0.98)
-            }
-            sx={{
-              minWidth: '122px',
-              border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
-              boxShadow:
+          {!hideDecline ? (
+            <CustomButtonAccept
+              customColor={theme.palette.text.primary}
+              customBgColor={
                 theme.palette.mode === 'dark'
-                  ? '0px 10px 24px rgba(0,0,0,0.24)'
-                  : '0px 8px 18px rgba(15,23,42,0.08)',
-              transition:
-                'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease',
-              '&:hover': {
-                backgroundColor:
-                  theme.palette.mode === 'dark'
-                    ? alpha('#21171c', 0.98)
-                    : alpha('#f8eef0', 0.98),
-                borderColor: alpha(theme.palette.error.main, 0.2),
+                  ? alpha('#171d27', 0.96)
+                  : alpha('#eef3f8', 0.98)
+              }
+              sx={{
+                minWidth: '122px',
+                border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
                 boxShadow:
                   theme.palette.mode === 'dark'
-                    ? '0px 14px 28px rgba(116, 34, 55, 0.2)'
-                    : '0px 12px 22px rgba(185, 28, 28, 0.08)',
-                transform: 'translateY(-1px)',
-              },
-            }}
-            onClick={onCancel}
-          >
-            {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
-          </CustomButtonAccept>
+                    ? '0px 10px 24px rgba(0,0,0,0.24)'
+                    : '0px 8px 18px rgba(15,23,42,0.08)',
+                transition:
+                  'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease',
+                '&:hover': {
+                  backgroundColor:
+                    theme.palette.mode === 'dark'
+                      ? alpha('#21171c', 0.98)
+                      : alpha('#f8eef0', 0.98),
+                  borderColor: alpha(theme.palette.error.main, 0.2),
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? '0px 14px 28px rgba(116, 34, 55, 0.2)'
+                      : '0px 12px 22px rgba(185, 28, 28, 0.08)',
+                  transform: 'translateY(-1px)',
+                },
+              }}
+              onClick={onCancel}
+            >
+              {declineLabel || t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
+            </CustomButtonAccept>
+          ) : null}
           <CustomButtonAccept
             customColor="#06111c"
             customBgColor={
@@ -642,7 +656,7 @@ export function QortalPermissionCard({
             }}
             onClick={onAccept}
           >
-            {t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
+            {acceptLabel || t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
           </CustomButtonAccept>
         </Box>
 

--- a/src/components/App/QortalRequestExtensionDialog.tsx
+++ b/src/components/App/QortalRequestExtensionDialog.tsx
@@ -1,4 +1,15 @@
-import { Box, Checkbox, Dialog, FormControlLabel, Typography, useTheme } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Checkbox,
+  Dialog,
+  FormControlLabel,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { JsonView, allExpanded, darkStyles } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
@@ -7,22 +18,14 @@ import { Spacer } from '../../common/Spacer';
 import { CustomButtonAccept, TextP } from '../../styles/App-styles.ts';
 import { ErrorText } from '../index';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
-
-export type MessageQortalRequestExtension = {
-  text1?: string;
-  text2?: string;
-  text3?: string;
-  text4?: string;
-  html?: string;
-  highlightedText?: string;
-  json?: any;
-  fee?: string;
-  appFee?: string;
-  foreignFee?: string;
-  checkbox1?: { label?: string; value?: boolean };
-  confirmCheckbox?: boolean;
-  confirmCheckboxLabel?: string;
-};
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
+import RadioButtonUncheckedRoundedIcon from '@mui/icons-material/RadioButtonUncheckedRounded';
+import type {
+  MessageQortalRequestExtension,
+  PermissionDetailSection,
+} from './qortalPermissionPresentation';
+import { buildPermissionPresentation } from './qortalPermissionPresentation';
 
 type QortalRequestExtensionDialogProps = {
   open: boolean;
@@ -34,7 +37,622 @@ type QortalRequestExtensionDialogProps = {
   onAccept: () => void;
   onCancel: () => void;
   onCountdownComplete: () => void;
+  countdownSeconds?: number;
 };
+
+type PermissionCardProps = {
+  message: MessageQortalRequestExtension;
+  sendPaymentError?: string;
+  confirmRequestRead: boolean;
+  onConfirmRequestReadChange: (checked: boolean) => void;
+  onCheckbox1Change: (checked: boolean) => void;
+  onAccept: () => void;
+  onCancel: () => void;
+  onCountdownComplete: () => void;
+  countdownSeconds?: number;
+};
+
+const renderDetailSection = (
+  section: PermissionDetailSection,
+  index: number,
+  theme: ReturnType<typeof useTheme>
+) => {
+  return (
+    <Box key={`${section.title || 'section'}-${index}`} sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      {section.title && (
+        <Typography
+          sx={{
+            color: theme.palette.text.secondary,
+            fontSize: '12px',
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {section.title}
+        </Typography>
+      )}
+      {section.rows?.length ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {section.rows.map((row, rowIndex) => (
+            <Box
+              key={`${row.label}-${rowIndex}`}
+              sx={{
+                alignItems: row.label ? 'baseline' : 'flex-start',
+                display: 'flex',
+                flexDirection: row.label ? 'row' : 'column',
+                gap: '10px',
+                justifyContent: 'space-between',
+              }}
+            >
+              {row.label ? (
+                <Typography
+                  sx={{
+                    color: theme.palette.text.secondary,
+                    fontSize: '13px',
+                    minWidth: '120px',
+                    textTransform: 'capitalize',
+                  }}
+                >
+                  {row.label}
+                </Typography>
+              ) : null}
+              <TextP
+                sx={{
+                  flex: 1,
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  lineHeight: 1.45,
+                  textAlign: row.label ? 'right' : 'left',
+                }}
+              >
+                {row.value}
+              </TextP>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
+      {section.html ? (
+        <Box
+          sx={{
+            '& *': {
+              color: `${theme.palette.text.primary} !important`,
+              fontFamily: 'Inter, sans-serif !important',
+            },
+            '& p, & li, & span, & div': {
+              lineHeight: '1.45 !important',
+            },
+            '& ul, & ol': {
+              margin: 0,
+              paddingLeft: '18px',
+            },
+          }}
+          dangerouslySetInnerHTML={{ __html: section.html }}
+        />
+      ) : null}
+      {section.json ? (
+        <Box
+          sx={{
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? alpha('#0f141b', 0.72)
+                : alpha('#f4f7fb', 0.92),
+            border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.045 : 0.04)}`,
+            borderRadius: '12px',
+            overflow: 'auto',
+            padding: '10px',
+            '& .json-view': {
+              backgroundColor: 'transparent !important',
+            },
+            '& .string-value, & .number-value, & .boolean-value, & .null-value, & .other-value, & .punctuation, & .data-type-label, & .object-key': {
+              color: `${alpha(theme.palette.text.secondary, theme.palette.mode === 'dark' ? 0.8 : 0.88)} !important`,
+            },
+          }}
+        >
+          <JsonView data={section.json} shouldExpandNode={allExpanded} style={darkStyles} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+export function QortalPermissionCard({
+  message,
+  sendPaymentError = '',
+  confirmRequestRead,
+  onConfirmRequestReadChange,
+  onCheckbox1Change,
+  onAccept,
+  onCancel,
+  onCountdownComplete,
+  countdownSeconds,
+}: PermissionCardProps) {
+  const theme = useTheme();
+  const { t } = useTranslation(['core']);
+  const presentation = buildPermissionPresentation(message, t);
+  const canAccept = !message.confirmCheckbox || confirmRequestRead;
+  const duration = countdownSeconds ?? message.countdownDuration ?? 60;
+  const hasDetailsAccordion = presentation.detailsSections.length > 0;
+  const requiresAcknowledgement = !!message.confirmCheckbox;
+  const acknowledgementMessage = requiresAcknowledgement
+    ? 'Please confirm before continuing.'
+    : '';
+
+  return (
+    <Box
+      sx={{
+        backgroundColor:
+          theme.palette.mode === 'dark'
+            ? alpha('#0d1117', 0.985)
+            : alpha('#ffffff', 0.985),
+        backgroundImage: 'none',
+        border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.07 : 0.06)}`,
+        borderRadius: '24px',
+        boxShadow:
+          theme.palette.mode === 'dark'
+            ? '0px 28px 72px rgba(0, 0, 0, 0.52)'
+            : '0px 18px 52px rgba(16, 24, 40, 0.14)',
+        color: theme.palette.text.primary,
+        display: 'flex',
+        flexDirection: 'column',
+        maxWidth: '560px',
+        overflow: 'hidden',
+        width: 'min(560px, calc(100vw - 32px))',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          padding: '26px',
+        }}
+      >
+        <Box
+          sx={{
+            alignItems: 'flex-start',
+            display: 'flex',
+            gap: '16px',
+            justifyContent: 'space-between',
+            width: '100%',
+            paddingBottom: '18px',
+            borderBottom: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
+          }}
+        >
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px', minWidth: 0 }}>
+            <Box
+              sx={{
+                alignItems: 'center',
+                color: alpha(theme.palette.text.secondary, 0.92),
+                display: 'flex',
+                gap: '8px',
+              }}
+            >
+              <ShieldOutlinedIcon sx={{ fontSize: '18px' }} />
+              <Typography
+                sx={{
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {presentation.sourceLabel
+                  ? `${presentation.sourceKind}: ${presentation.sourceLabel}`
+                  : `${presentation.sourceKind} request`}
+              </Typography>
+            </Box>
+            <TextP
+              sx={{
+                fontSize: '29px',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.12,
+              }}
+            >
+              {presentation.title}
+            </TextP>
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.secondary, 0.92),
+                fontSize: '14px',
+                lineHeight: 1.5,
+                maxWidth: '440px',
+              }}
+            >
+              {presentation.body}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              alignItems: 'center',
+              backgroundColor:
+                theme.palette.mode === 'dark'
+                  ? alpha('#0e141c', 0.95)
+                  : alpha('#f2f5f8', 0.98),
+              border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.14)}`,
+              borderRadius: '999px',
+              display: 'flex',
+              justifyContent: 'center',
+              minWidth: '74px',
+              padding: '6px 10px',
+            }}
+          >
+            <CountdownCircleTimer
+              isPlaying
+              duration={duration}
+              colors={['#2D7FF9', '#E8A13A', '#C45151', '#C45151']}
+              colorsTime={[Math.max(duration * 0.4, 10), Math.max(duration * 0.2, 5), 3, 0]}
+              onComplete={onCountdownComplete}
+              size={42}
+              strokeWidth={4}
+              trailColor={alpha(theme.palette.common.white, 0.12)}
+            >
+              {({ remainingTime }) => (
+                <TextP sx={{ fontSize: '13px', fontWeight: 700 }}>{remainingTime}</TextP>
+              )}
+            </CountdownCircleTimer>
+          </Box>
+        </Box>
+
+        <Spacer height="22px" />
+
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '14px',
+            width: '100%',
+          }}
+        >
+          <Typography
+            sx={{
+              color: alpha(theme.palette.text.secondary, 0.82),
+              fontSize: '12px',
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            What you are approving
+          </Typography>
+
+          {presentation.summaryItems.length ? (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {presentation.summaryItems.map((row, index) => (
+                row.label ? (
+                  <Box
+                    key={`${row.label}-${index}`}
+                    sx={{
+                      alignItems: 'baseline',
+                      display: 'flex',
+                      gap: '10px',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        color: alpha(theme.palette.text.secondary, 0.92),
+                        fontSize: '13px',
+                        minWidth: '110px',
+                        textTransform: 'capitalize',
+                      }}
+                    >
+                      {row.label}
+                    </Typography>
+                    <TextP
+                      sx={{
+                        flex: 1,
+                        fontSize: '15px',
+                        fontWeight: 600,
+                        lineHeight: 1.42,
+                        textAlign: 'right',
+                      }}
+                    >
+                      {row.value}
+                    </TextP>
+                  </Box>
+                ) : (
+                  <Box
+                    key={`bullet-${index}`}
+                    sx={{
+                      alignItems: 'flex-start',
+                      display: 'flex',
+                      gap: '10px',
+                    }}
+                  >
+                    <RadioButtonUncheckedRoundedIcon
+                      sx={{
+                        color: alpha(theme.palette.primary.main, 0.7),
+                        fontSize: '12px',
+                        marginTop: '5px',
+                      }}
+                    />
+                    <Typography
+                      sx={{
+                        color: theme.palette.text.primary,
+                        fontSize: '15px',
+                        fontWeight: 500,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      {row.value}
+                    </Typography>
+                  </Box>
+                )
+              ))}
+            </Box>
+          ) : null}
+
+          {presentation.feeItems.length ? (
+            <Box
+              sx={{
+                borderTop: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '10px',
+                paddingTop: '16px',
+              }}
+            >
+              {presentation.feeItems.map((row, index) => (
+                <Box
+                  key={`${row.label}-${index}`}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    gap: '12px',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <Typography sx={{ color: theme.palette.text.secondary, fontSize: '13px' }}>
+                    {row.label}
+                  </Typography>
+                  <TextP sx={{ fontSize: '14px', fontWeight: 700 }}>{row.value}</TextP>
+                </Box>
+              ))}
+            </Box>
+          ) : null}
+        </Box>
+
+        {(message.checkbox1 || message.confirmCheckbox) ? (
+          <>
+            <Spacer height="16px" />
+            <Box
+              sx={{
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#131922', 0.82)
+                    : alpha('#f5f8fb', 0.92),
+                border: `1px solid ${alpha(
+                  requiresAcknowledgement ? theme.palette.warning.main : theme.palette.common.white,
+                  requiresAcknowledgement ? 0.22 : theme.palette.mode === 'dark' ? 0.06 : 0.05
+                )}`,
+                borderRadius: '16px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+                padding: '12px 14px',
+                width: '100%',
+              }}
+            >
+              {message.checkbox1 ? (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      onChange={(event) => onCheckbox1Change(event.target.checked)}
+                      edge="start"
+                      tabIndex={-1}
+                      disableRipple
+                      defaultChecked={message.checkbox1?.value}
+                      sx={{
+                        '&.Mui-checked': {
+                          color: theme.palette.text.secondary,
+                        },
+                        '& .MuiSvgIcon-root': {
+                          color: theme.palette.text.secondary,
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px' }}>
+                      {message.checkbox1?.label}
+                    </Typography>
+                  }
+                  sx={{ margin: 0 }}
+                />
+              ) : null}
+
+              {message.confirmCheckbox ? (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      onChange={(event) => onConfirmRequestReadChange(event.target.checked)}
+                      checked={confirmRequestRead}
+                      edge="start"
+                      tabIndex={-1}
+                      disableRipple
+                      sx={{
+                        '&.Mui-checked': {
+                          color: theme.palette.text.secondary,
+                        },
+                        '& .MuiSvgIcon-root': {
+                          color: theme.palette.text.secondary,
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Box sx={{ alignItems: 'center', display: 'flex', gap: '8px', paddingRight: '8px' }}>
+                      <Typography sx={{ color: theme.palette.text.primary, fontSize: '14px', lineHeight: 1.45 }}>
+                        {message.confirmCheckboxLabel ||
+                          t('core:message.success.request_read', {
+                            postProcess: 'capitalizeFirstChar',
+                          })}
+                      </Typography>
+                      <PriorityHighIcon color="warning" sx={{ fontSize: '18px' }} />
+                    </Box>
+                  }
+                  sx={{ margin: 0 }}
+                />
+              ) : null}
+            </Box>
+            {requiresAcknowledgement && !canAccept ? (
+              <Typography
+                sx={{
+                  color: alpha(theme.palette.warning.light, 0.92),
+                  fontSize: '13px',
+                  lineHeight: 1.45,
+                  marginTop: '8px',
+                }}
+              >
+                {acknowledgementMessage}
+              </Typography>
+            ) : null}
+          </>
+        ) : null}
+
+        {hasDetailsAccordion ? (
+          <>
+            <Spacer height="16px" />
+            <Accordion
+              sx={{
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#121821', 0.72)
+                    : alpha('#f4f7fb', 0.96),
+                backgroundImage: 'none',
+                border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.06 : 0.05)}`,
+                borderRadius: '18px !important',
+                boxShadow: 'none',
+                color: theme.palette.text.primary,
+                width: '100%',
+                '&:before': {
+                  display: 'none',
+                },
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMoreRoundedIcon sx={{ color: theme.palette.text.secondary }} />}
+                sx={{
+                  minHeight: '56px',
+                  padding: '0 18px',
+                  '& .MuiAccordionSummary-content': {
+                    margin: '14px 0',
+                  },
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: theme.palette.text.primary,
+                    fontSize: '15px',
+                    fontWeight: 700,
+                  }}
+                >
+                  More details
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails sx={{ padding: '0 18px 18px' }}>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
+                  {presentation.detailsSections.map((section, index) =>
+                    renderDetailSection(section, index, theme)
+                  )}
+                </Box>
+              </AccordionDetails>
+            </Accordion>
+          </>
+        ) : null}
+
+        <Spacer height="22px" />
+
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            gap: '12px',
+            justifyContent: 'flex-end',
+            width: '100%',
+          }}
+        >
+          <CustomButtonAccept
+            customColor={theme.palette.text.primary}
+            customBgColor={
+              theme.palette.mode === 'dark'
+                ? alpha('#171d27', 0.96)
+                : alpha('#eef3f8', 0.98)
+            }
+            sx={{
+              minWidth: '122px',
+              border: `1px solid ${alpha(theme.palette.common.white, theme.palette.mode === 'dark' ? 0.08 : 0.06)}`,
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0px 10px 24px rgba(0,0,0,0.24)'
+                  : '0px 8px 18px rgba(15,23,42,0.08)',
+              transition:
+                'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease',
+              '&:hover': {
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? alpha('#21171c', 0.98)
+                    : alpha('#f8eef0', 0.98),
+                borderColor: alpha(theme.palette.error.main, 0.2),
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0px 14px 28px rgba(116, 34, 55, 0.2)'
+                    : '0px 12px 22px rgba(185, 28, 28, 0.08)',
+                transform: 'translateY(-1px)',
+              },
+            }}
+            onClick={onCancel}
+          >
+            {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
+          </CustomButtonAccept>
+          <CustomButtonAccept
+            customColor="#06111c"
+            customBgColor={
+              theme.palette.mode === 'dark'
+                ? '#76aef4'
+                : '#6da5eb'
+            }
+            sx={{
+              minWidth: '122px',
+              opacity: canAccept ? 1 : 0.35,
+              cursor: canAccept ? 'pointer' : 'default',
+              border: `1px solid ${alpha('#b6d3ff', 0.26)}`,
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0px 10px 24px rgba(58, 112, 188, 0.26)'
+                  : '0px 8px 18px rgba(67, 112, 181, 0.16)',
+              transition:
+                'background-color 180ms ease, border-color 180ms ease, box-shadow 200ms ease, transform 180ms ease, opacity 180ms ease',
+              '&:hover': {
+                opacity: canAccept ? 1 : 0.35,
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? '#86baf8'
+                    : '#78aff0',
+                borderColor: alpha('#d2e4ff', 0.36),
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0px 14px 30px rgba(76, 133, 214, 0.28)'
+                    : '0px 12px 24px rgba(77, 124, 212, 0.18)',
+                transform: canAccept ? 'translateY(-1px)' : 'none',
+              },
+            }}
+            onClick={onAccept}
+          >
+            {t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
+          </CustomButtonAccept>
+        </Box>
+
+        {sendPaymentError ? (
+          <ErrorText sx={{ marginTop: '12px', width: '100%' }}>{sendPaymentError}</ErrorText>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}
 
 export function QortalRequestExtensionDialog({
   open,
@@ -46,10 +664,8 @@ export function QortalRequestExtensionDialog({
   onAccept,
   onCancel,
   onCountdownComplete,
+  countdownSeconds,
 }: QortalRequestExtensionDialogProps) {
-  const theme = useTheme();
-  const { t } = useTranslation(['core']);
-
   if (!open) return null;
 
   return (
@@ -57,300 +673,28 @@ export function QortalRequestExtensionDialog({
       open={open}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
+      PaperProps={{
+        sx: {
+          backgroundColor: 'transparent',
+          backgroundImage: 'none',
+          boxShadow: 'none',
+          overflow: 'visible',
+        },
+      }}
     >
-      <CountdownCircleTimer
-        isPlaying
-        duration={60}
-        colors={['#004777', '#F7B801', '#A30000', '#A30000']}
-        colorsTime={[7, 5, 2, 0]}
-        onComplete={onCountdownComplete}
-        size={50}
-        strokeWidth={5}
-      >
-        {({ remainingTime }) => <TextP>{remainingTime}</TextP>}
-      </CountdownCircleTimer>
-      <Box
-        sx={{
-          alignItems: 'center',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'flex-start',
-          maxHeight: '90vh',
-          overflow: 'auto',
-          padding: '20px',
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            width: '100%',
-          }}
-        >
-          <TextP
-            sx={{
-              lineHeight: 1.2,
-              maxWidth: '90%',
-              textAlign: 'center',
-              fontSize: '16px',
-              marginBottom: '10px',
-            }}
-          >
-            {message?.text1}
-          </TextP>
-        </Box>
-        {message?.text2 && (
-          <>
-            <Spacer height="10px" />
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'flex-start',
-                width: '90%',
-              }}
-            >
-              <TextP
-                sx={{
-                  lineHeight: 1.2,
-                  fontSize: '16px',
-                  fontWeight: 'normal',
-                }}
-              >
-                {message.text2}
-              </TextP>
-            </Box>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.text3 && (
-          <>
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'flex-start',
-                width: '90%',
-              }}
-            >
-              <TextP
-                sx={{
-                  lineHeight: 1.2,
-                  fontSize: '16px',
-                  fontWeight: 'normal',
-                }}
-              >
-                {message.text3}
-              </TextP>
-            </Box>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.text4 && (
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'flex-start',
-              width: '90%',
-            }}
-          >
-            <TextP
-              sx={{
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-              }}
-            >
-              {message.text4}
-            </TextP>
-          </Box>
-        )}
-        {message?.html && (
-          <>
-            <Spacer height="15px" />
-            <div dangerouslySetInnerHTML={{ __html: message.html }} />
-          </>
-        )}
-        <Spacer height="15px" />
-        <TextP
-          sx={{
-            textAlign: 'center',
-            lineHeight: 1.2,
-            fontSize: '16px',
-            fontWeight: 700,
-            maxWidth: '90%',
-          }}
-        >
-          {message?.highlightedText}
-        </TextP>
-        {message?.json && (
-          <>
-            <Spacer height="15px" />
-            <JsonView
-              data={message.json}
-              shouldExpandNode={allExpanded}
-              style={darkStyles}
-            />
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.fee && (
-          <>
-            <Spacer height="15px" />
-            <TextP
-              sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
-              }}
-            >
-              {'Fee: '}
-              {message.fee}
-              {' QORT'}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.appFee && (
-          <>
-            <TextP
-              sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
-              }}
-            >
-              {t('core:message.generic.fee_qort', {
-                fee: message.appFee,
-                postProcess: 'capitalizeFirstChar',
-              })}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.foreignFee && (
-          <>
-            <Spacer height="15px" />
-            <TextP
-              sx={{
-                textAlign: 'center',
-                lineHeight: 1.2,
-                fontSize: '16px',
-                fontWeight: 'normal',
-                maxWidth: '90%',
-              }}
-            >
-              {t('core:message.generic.foreign_fee', {
-                fee: message.foreignFee,
-                postProcess: 'capitalizeFirstChar',
-              })}
-            </TextP>
-            <Spacer height="15px" />
-          </>
-        )}
-        {message?.checkbox1 && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '90%',
-              marginTop: '20px',
-            }}
-          >
-            <Checkbox
-              onChange={(e) => onCheckbox1Change(e.target.checked)}
-              edge="start"
-              tabIndex={-1}
-              disableRipple
-              defaultChecked={message.checkbox1?.value}
-              sx={{
-                '&.Mui-checked': {
-                  color: theme.palette.text.secondary,
-                },
-                '& .MuiSvgIcon-root': {
-                  color: theme.palette.text.secondary,
-                },
-              }}
-            />
-            <Typography sx={{ fontSize: '14px' }}>
-              {message.checkbox1?.label}
-            </Typography>
-          </Box>
-        )}
-        {message?.confirmCheckbox && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                onChange={(e) => onConfirmRequestReadChange(e.target.checked)}
-                checked={confirmRequestRead}
-                edge="start"
-                tabIndex={-1}
-                disableRipple
-                sx={{
-                  '&.Mui-checked': {
-                    color: theme.palette.text.secondary,
-                  },
-                  '& .MuiSvgIcon-root': {
-                    color: theme.palette.text.secondary,
-                  },
-                }}
-              />
-            }
-            label={
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <Typography sx={{ fontSize: '14px' }}>
-                  {message.confirmCheckboxLabel ||
-                    t('core:message.success.request_read', {
-                      postProcess: 'capitalizeFirstChar',
-                    })}
-                </Typography>
-                <PriorityHighIcon color="warning" />
-              </Box>
-            }
-          />
-        )}
-        <Spacer height="29px" />
-        <Box
-          sx={{
-            alignItems: 'center',
-            display: 'flex',
-            gap: '14px',
-          }}
-        >
-          <CustomButtonAccept
-            customColor="black"
-            customBgColor={theme.palette.other.positive}
-            sx={{
-              minWidth: '102px',
-              opacity:
-                message?.confirmCheckbox && !confirmRequestRead ? 0.1 : 0.7,
-              cursor:
-                message?.confirmCheckbox && !confirmRequestRead
-                  ? 'default'
-                  : 'pointer',
-              '&:hover': {
-                opacity:
-                  message?.confirmCheckbox && !confirmRequestRead ? 0.1 : 1,
-              },
-            }}
-            onClick={onAccept}
-          >
-            {t('core:action.accept', { postProcess: 'capitalizeFirstChar' })}
-          </CustomButtonAccept>
-          <CustomButtonAccept
-            customColor="black"
-            customBgColor={theme.palette.other.danger}
-            sx={{ minWidth: '102px' }}
-            onClick={onCancel}
-          >
-            {t('core:action.decline', { postProcess: 'capitalizeFirstChar' })}
-          </CustomButtonAccept>
-        </Box>
-        <ErrorText>{sendPaymentError}</ErrorText>
-      </Box>
+      <QortalPermissionCard
+        message={(message || {}) as MessageQortalRequestExtension}
+        sendPaymentError={sendPaymentError}
+        confirmRequestRead={confirmRequestRead}
+        onConfirmRequestReadChange={onConfirmRequestReadChange}
+        onCheckbox1Change={onCheckbox1Change}
+        onAccept={onAccept}
+        onCancel={onCancel}
+        onCountdownComplete={onCountdownComplete}
+        countdownSeconds={countdownSeconds}
+      />
     </Dialog>
   );
 }
+
+export type { MessageQortalRequestExtension } from './qortalPermissionPresentation';

--- a/src/components/App/qortalPermissionPresentation.ts
+++ b/src/components/App/qortalPermissionPresentation.ts
@@ -1,0 +1,522 @@
+export type PermissionDetailRow = {
+  label?: string;
+  value: string;
+};
+
+export type PermissionDetailSection = {
+  title?: string;
+  rows?: PermissionDetailRow[];
+  html?: string;
+  json?: any;
+};
+
+export type MessageQortalRequestExtension = {
+  text1?: string;
+  text2?: string;
+  text3?: string;
+  text4?: string;
+  html?: string;
+  highlightedText?: string;
+  json?: any;
+  fee?: string;
+  appFee?: string;
+  foreignFee?: string;
+  checkbox1?: { label?: string; value?: boolean };
+  confirmCheckbox?: boolean;
+  confirmCheckboxLabel?: string;
+  requestType?: string;
+  sourceLabel?: string;
+  sourceKind?: 'Q-App' | 'Application' | 'Extension';
+  summaryTitle?: string;
+  summaryBody?: string;
+  summaryItems?: PermissionDetailRow[];
+  technicalDetails?: PermissionDetailSection[];
+  countdownDuration?: number;
+};
+
+export type PermissionPresentation = {
+  sourceLabel?: string;
+  sourceKind: string;
+  title: string;
+  body: string;
+  summaryItems: PermissionDetailRow[];
+  feeItems: PermissionDetailRow[];
+  detailsSections: PermissionDetailSection[];
+};
+
+export const MODAL_REQUEST_TYPES = [
+  'ADD_FOREIGN_SERVER',
+  'ADD_GROUP_ADMIN',
+  'ADD_LIST_ITEMS',
+  'ADMIN_ACTION',
+  'BAN_FROM_GROUP',
+  'BUY_NAME',
+  'CANCEL_GROUP_BAN',
+  'CANCEL_GROUP_INVITE',
+  'CANCEL_SELL_NAME',
+  'CANCEL_TRADE_SELL_ORDER',
+  'CREATE_GROUP',
+  'CREATE_POLL',
+  'CREATE_TRADE_BUY_ORDER',
+  'CREATE_TRADE_SELL_ORDER',
+  'DELETE_HOSTED_DATA',
+  'DELETE_LIST_ITEM',
+  'DEPLOY_AT',
+  'GET_HOSTED_DATA',
+  'GET_LIST_ITEMS',
+  'GET_USER_ACCOUNT',
+  'GET_USER_WALLET',
+  'GET_USER_WALLET_INFO',
+  'GET_USER_WALLET_TRANSACTIONS',
+  'GET_WALLET_BALANCE',
+  'INVITE_TO_GROUP',
+  'JOIN_GROUP',
+  'KICK_FROM_GROUP',
+  'LEAVE_GROUP',
+  'LOCK_TAB',
+  'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA',
+  'PUBLISH_MULTIPLE_QDN_RESOURCES',
+  'PUBLISH_QDN_RESOURCE',
+  'REENCRYPT_GROUP_KEYS',
+  'REGISTER_NAME',
+  'REMOVE_FOREIGN_SERVER',
+  'REMOVE_GROUP_ADMIN',
+  'SAVE_FILE',
+  'SELL_NAME',
+  'SEND_CHAT_MESSAGE',
+  'SEND_COIN',
+  'SESSION_PERMISSIONS',
+  'SET_CURRENT_FOREIGN_SERVER',
+  'SIGN_FOREIGN_FEES',
+  'SIGN_TRANSACTION',
+  'TRANSFER_ASSET',
+  'UPDATE_FOREIGN_FEE',
+  'UPDATE_GROUP',
+  'UPDATE_NAME',
+  'VOTE_ON_POLL',
+] as const;
+
+const REQUEST_ACTION_LABELS: Record<string, string> = {
+  ADD_FOREIGN_SERVER: 'add a server',
+  ADD_GROUP_ADMIN: 'add a group admin',
+  ADD_LIST_ITEMS: 'add items to a list',
+  ADMIN_ACTION: 'perform an admin action',
+  BAN_FROM_GROUP: 'ban a user from a group',
+  BUY_NAME: 'buy a name',
+  CANCEL_GROUP_BAN: 'cancel a group ban',
+  CANCEL_GROUP_INVITE: 'cancel a group invite',
+  CANCEL_SELL_NAME: 'cancel a name sale',
+  CANCEL_TRADE_SELL_ORDER: 'cancel a trade sell order',
+  CREATE_GROUP: 'create a group',
+  CREATE_POLL: 'create a poll',
+  CREATE_TRADE_BUY_ORDER: 'create a trade buy order',
+  CREATE_TRADE_SELL_ORDER: 'create a trade sell order',
+  DELETE_HOSTED_DATA: 'delete hosted data',
+  DELETE_LIST_ITEM: 'delete a list item',
+  DEPLOY_AT: 'deploy an AT',
+  GET_USER_ACCOUNT: 'authenticate',
+  GET_HOSTED_DATA: 'access hosted data',
+  GET_LIST_ITEMS: 'access list items',
+  SESSION_PERMISSIONS: 'request session permissions',
+  INVITE_TO_GROUP: 'invite to a group',
+  PUBLISH_QDN_RESOURCE: 'publish data',
+  PUBLISH_MULTIPLE_QDN_RESOURCES: 'publish multiple resources',
+  KICK_FROM_GROUP: 'remove a user from a group',
+  LOCK_TAB: 'lock this tab',
+  REMOVE_FOREIGN_SERVER: 'remove a server',
+  REMOVE_GROUP_ADMIN: 'remove a group admin',
+  SAVE_FILE: 'save a file',
+  SELL_NAME: 'sell a name',
+  SEND_COIN: 'send a payment',
+  SET_CURRENT_FOREIGN_SERVER: 'change server settings',
+  SIGN_TRANSACTION: 'sign a transaction',
+  SIGN_FOREIGN_FEES: 'sign foreign fees',
+  MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA: 'send a payment and publish private data',
+  GET_USER_WALLET: 'access wallet details',
+  GET_WALLET_BALANCE: 'access wallet balances',
+  GET_USER_WALLET_INFO: 'access wallet information',
+  GET_USER_WALLET_TRANSACTIONS: 'access wallet transactions',
+  TRANSFER_ASSET: 'transfer an asset',
+  UPDATE_FOREIGN_FEE: 'update foreign fees',
+  UPDATE_GROUP: 'update a group',
+  REGISTER_NAME: 'register a name',
+  UPDATE_NAME: 'update a name',
+  JOIN_GROUP: 'join a group',
+  LEAVE_GROUP: 'leave a group',
+  SEND_CHAT_MESSAGE: 'send a chat message',
+  VOTE_ON_POLL: 'vote on a poll',
+};
+
+const formatServiceName = (service?: string) => {
+  if (!service) return 'Unknown';
+  return service
+    .toLowerCase()
+    .split('_')
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const QDN_SERVICE_SUMMARIES: Record<string, string> = {
+  APP: 'This publishes a Q-App resource to QDN.',
+  DOCUMENT: 'This publishes document-style content to QDN.',
+  DOCUMENT_PRIVATE: 'This publishes encrypted private document data to QDN.',
+  IMAGE: 'This publishes image data to QDN.',
+  VIDEO: 'This publishes video content to QDN.',
+  THUMBNAIL: 'This publishes thumbnail-style media to QDN.',
+  WEBSITE: 'This publishes website content to QDN.',
+  BLOG: 'This publishes blog content to QDN.',
+};
+
+const humanizeRequestType = (requestType?: string) => {
+  if (!requestType) return 'make a change to your account';
+  if (REQUEST_ACTION_LABELS[requestType]) return REQUEST_ACTION_LABELS[requestType];
+  return 'make a change to your account';
+};
+
+const sanitizeQuestionCopy = (value?: string) => {
+  if (!value) return '';
+
+  return value
+    .replace(/^do you give this application permission to\s*/i, '')
+    .replace(/^this application is requesting\s*/i, '')
+    .replace(/\?$/u, '')
+    .trim();
+};
+
+const parseDetailRow = (value?: string): PermissionDetailRow | null => {
+  if (!value?.trim()) return null;
+
+  const trimmed = value.trim();
+  const separatorIndex = trimmed.indexOf(':');
+
+  if (separatorIndex > 0) {
+    return {
+      label: trimmed.slice(0, separatorIndex).trim(),
+      value: trimmed.slice(separatorIndex + 1).trim() || '-',
+    };
+  }
+
+  return {
+    value: trimmed,
+  };
+};
+
+const getDetailRowValue = (
+  rows: PermissionDetailRow[],
+  targetLabel: string
+) => {
+  return rows.find((row) => row.label?.toLowerCase() === targetLabel.toLowerCase())?.value;
+};
+
+const parsePublishMultipleSummary = (html?: string) => {
+  if (!html) {
+    return { resourceCount: 0, includesPrivateData: false };
+  }
+
+  const resourceCount = (html.match(/resource-container/g) || []).length;
+  const includesPrivateData = /_PRIVATE|encrypted/iu.test(html);
+
+  return {
+    resourceCount,
+    includesPrivateData,
+  };
+};
+
+const getJsonValue = (json: any, candidateKeys: string[]) => {
+  if (!json || typeof json !== 'object') return undefined;
+
+  for (const key of candidateKeys) {
+    if (json[key] != null) {
+      return json[key];
+    }
+  }
+
+  return undefined;
+};
+
+const buildTitle = (message: MessageQortalRequestExtension) => {
+  if (message.summaryTitle) return message.summaryTitle;
+
+  const sourceLabel = message.sourceLabel?.trim();
+  const requestType = message.requestType;
+  const actionLabel = humanizeRequestType(requestType);
+
+  if (sourceLabel) {
+    return `${sourceLabel} wants to ${actionLabel}`;
+  }
+
+  const sanitized = sanitizeQuestionCopy(message.text1);
+  return `This application wants to ${REQUEST_ACTION_LABELS[requestType || ''] || sanitized || actionLabel}`;
+};
+
+const buildBody = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  if (message.summaryBody) return message.summaryBody;
+
+  const requestType = message.requestType;
+  const serviceRow = parseDetailRow(message.text2);
+  const serviceValue = serviceRow?.label?.toLowerCase() === 'service' ? serviceRow.value : '';
+
+  switch (requestType) {
+    case 'GET_USER_ACCOUNT':
+      return 'This app can confirm your Qortal identity. It cannot send payments or publish data.';
+    case 'SESSION_PERMISSIONS':
+      return 'Approved permissions can run automatically for this session only.';
+    case 'ADD_FOREIGN_SERVER':
+      return 'This adds a foreign server configuration to your Qortal environment.';
+    case 'PUBLISH_QDN_RESOURCE':
+      return (
+        QDN_SERVICE_SUMMARIES[serviceValue] ||
+        `This action will publish data to QDN using the ${serviceValue || 'selected'} service.`
+      );
+    case 'PUBLISH_MULTIPLE_QDN_RESOURCES':
+      return 'Multiple QDN resources will be published using your account.';
+    case 'SEND_COIN':
+      return 'This sends funds from your wallet to the specified recipient.';
+    case 'SIGN_TRANSACTION':
+      return 'This app wants your account to sign a transaction.';
+    case 'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA':
+      return 'This will send a payment and publish private encrypted data in the same action.';
+    case 'REMOVE_FOREIGN_SERVER':
+      return 'This removes a saved foreign server configuration from your Qortal environment.';
+    case 'SET_CURRENT_FOREIGN_SERVER':
+      return 'This changes which foreign server your Qortal environment will use.';
+    case 'GET_USER_WALLET':
+    case 'GET_WALLET_BALANCE':
+    case 'GET_USER_WALLET_INFO':
+    case 'GET_USER_WALLET_TRANSACTIONS':
+      return 'This gives the application access to wallet-related information from your Qortal account.';
+    default:
+      return 'Review the details of this action before approving.';
+  }
+};
+
+const buildSummaryItems = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  if (message.summaryItems?.length) return message.summaryItems;
+
+  const requestType = message.requestType;
+  const rows = [message.text2, message.text3, message.text4]
+    .map(parseDetailRow)
+    .filter(Boolean) as PermissionDetailRow[];
+
+  const serviceValue = getDetailRowValue(rows, 'service');
+  const nameValue = getDetailRowValue(rows, 'name');
+  const recipientValue = getDetailRowValue(rows, 'to');
+
+  if (requestType === 'GET_USER_ACCOUNT') {
+    return [
+      { value: 'This app can confirm your Qortal identity' },
+      { value: 'It cannot send payments' },
+      { value: 'It will not publish data' },
+    ];
+  }
+
+  if (requestType === 'SESSION_PERMISSIONS') {
+    return [
+      {
+        value: 'Approved permissions can run automatically for this session only',
+      },
+      { value: 'These permissions stop when the session ends' },
+    ];
+  }
+
+  if (requestType === 'ADD_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will add a foreign server configuration' },
+      { value: 'Make sure you trust the server details below.' },
+    ];
+  }
+
+  if (requestType === 'PUBLISH_QDN_RESOURCE') {
+    return [
+      { value: 'This will publish data to QDN using your account' },
+      ...(serviceValue ? [{ label: 'Content type', value: formatServiceName(serviceValue) }] : []),
+      ...(nameValue ? [{ label: 'Publishing name', value: nameValue }] : []),
+    ];
+  }
+
+  if (requestType === 'PUBLISH_MULTIPLE_QDN_RESOURCES') {
+    const { resourceCount, includesPrivateData } = parsePublishMultipleSummary(message.html);
+    return [
+      { value: 'Multiple QDN resources will be published using your account' },
+      ...(includesPrivateData
+        ? [{ value: 'Some resources include private or encrypted data' }]
+        : []),
+      ...(resourceCount > 0
+        ? [{ label: 'Resources in this request', value: `${resourceCount}` }]
+        : []),
+    ];
+  }
+
+  if (requestType === 'SEND_COIN') {
+    return [
+      ...(message.highlightedText ? [{ label: 'Amount', value: message.highlightedText }] : []),
+      ...(recipientValue ? [{ label: 'Recipient', value: recipientValue }] : []),
+    ];
+  }
+
+  if (
+    requestType === 'GET_USER_WALLET' ||
+    requestType === 'GET_USER_WALLET_INFO' ||
+    requestType === 'GET_USER_WALLET_TRANSACTIONS'
+  ) {
+    return [
+      { value: 'This app can view wallet-related information from your Qortal account' },
+      ...(message.highlightedText ? [{ label: 'Wallet', value: message.highlightedText.replace(/^coin:\s*/iu, '') }] : []),
+    ];
+  }
+
+  if (requestType === 'GET_WALLET_BALANCE') {
+    return [
+      { value: 'This app can view your wallet balance' },
+      ...(message.text1?.includes('{{ coin }}') ? [] : []),
+    ];
+  }
+
+  if (requestType === 'SIGN_TRANSACTION') {
+    const txType = getJsonValue(message.json, ['type']);
+    const recipient = getJsonValue(message.json, ['recipient', 'recipientAddress']);
+    const amount = getJsonValue(message.json, ['amount', 'amountQort']);
+    return [
+      { value: 'This app wants your account to sign a transaction' },
+      ...(txType != null ? [{ label: 'Transaction type', value: String(txType) }] : []),
+      ...(recipient != null ? [{ label: 'Recipient', value: String(recipient) }] : []),
+      ...(amount != null ? [{ label: 'Amount', value: String(amount) }] : []),
+    ];
+  }
+
+  if (requestType === 'REMOVE_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will remove a saved foreign server configuration' },
+      { value: 'Review the server details below before approving' },
+    ];
+  }
+
+  if (requestType === 'SET_CURRENT_FOREIGN_SERVER') {
+    return [
+      { value: 'This action will change the foreign server currently in use' },
+      { value: 'Review the server details below before approving' },
+    ];
+  }
+
+  const summaryRows = rows.slice(0, message.highlightedText ? 1 : 2);
+  if (message.highlightedText) {
+    return [{ value: message.highlightedText }, ...summaryRows];
+  }
+
+  if (summaryRows.length > 0) {
+    return summaryRows;
+  }
+
+  return [
+    { value: 'This action will modify your Qortal account or data' },
+    { value: 'Review the technical details below before approving' },
+  ];
+};
+
+const buildFeeItems = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  const feeItems: PermissionDetailRow[] = [];
+
+  if (message.fee) {
+    feeItems.push({ label: 'Network fee', value: `${message.fee} QORT` });
+  }
+
+  if (message.appFee) {
+    feeItems.push({
+      label: t('core:message.generic.fee_qort', {
+        fee: message.appFee,
+        postProcess: 'capitalizeFirstChar',
+      }).split(':')[0] || 'App fee',
+      value: `${message.appFee} QORT`,
+    });
+  }
+
+  if (message.foreignFee) {
+    feeItems.push({
+      label: t('core:message.generic.foreign_fee', {
+        fee: message.foreignFee,
+        postProcess: 'capitalizeFirstChar',
+      }).split(':')[0] || 'Foreign fee',
+      value: message.foreignFee,
+    });
+  }
+
+  return feeItems;
+};
+
+const buildDetailsSections = (message: MessageQortalRequestExtension) => {
+  const sections: PermissionDetailSection[] = [];
+
+  const rows = [message.text2, message.text3, message.text4]
+    .map(parseDetailRow)
+    .filter(Boolean) as PermissionDetailRow[];
+
+  const summaryRows = buildSummaryItems(message, () => '');
+  const summaryKeys = new Set(summaryRows.map((row) => `${row.label}:${row.value}`));
+  const fallbackRows = rows.filter((row) => !summaryKeys.has(`${row.label}:${row.value}`));
+
+  const technicalRows: PermissionDetailRow[] = [];
+  const technicalKeys = new Set<string>();
+  const normalizeLabel = (label?: string) => (label || '').trim().toLowerCase();
+  const pushTechnicalRow = (row?: PermissionDetailRow | null) => {
+    if (!row) return;
+    const key = `${normalizeLabel(row.label)}:${row.value}`;
+    if (technicalKeys.has(key)) return;
+    technicalKeys.add(key);
+    technicalRows.push(row);
+  };
+
+  pushTechnicalRow(
+    message.requestType ? { label: 'Request type', value: message.requestType } : null
+  );
+
+  for (const section of message.technicalDetails || []) {
+    for (const row of section.rows || []) {
+      pushTechnicalRow(row);
+    }
+  }
+
+  for (const row of fallbackRows) {
+    pushTechnicalRow(row);
+  }
+
+  if (technicalRows.length > 0) {
+    sections.push({ title: 'Technical details', rows: technicalRows });
+  }
+
+  const shouldShowHtmlPayload =
+    !!message.html && message.requestType !== 'PUBLISH_MULTIPLE_QDN_RESOURCES';
+
+  if (shouldShowHtmlPayload) {
+    sections.push({ title: 'Request payload', html: message.html });
+  }
+
+  if (message.json) {
+    sections.push({ title: 'Raw payload', json: message.json });
+  }
+
+  return sections;
+};
+
+export const buildPermissionPresentation = (
+  message: MessageQortalRequestExtension,
+  t: (key: string, options?: Record<string, unknown>) => string
+): PermissionPresentation => {
+  return {
+    sourceLabel: message.sourceLabel,
+    sourceKind: message.sourceKind || 'Application',
+    title: buildTitle(message),
+    body: buildBody(message, t),
+    summaryItems: buildSummaryItems(message, t),
+    feeItems: buildFeeItems(message, t),
+    detailsSections: buildDetailsSections(message),
+  };
+};

--- a/src/components/App/qortalPermissionPresentation.ts
+++ b/src/components/App/qortalPermissionPresentation.ts
@@ -96,7 +96,7 @@ export const MODAL_REQUEST_TYPES = [
   'VOTE_ON_POLL',
 ] as const;
 
-const REQUEST_ACTION_LABELS: Record<string, string> = {
+export const REQUEST_ACTION_LABELS: Record<string, string> = {
   ADD_FOREIGN_SERVER: 'add a server',
   ADD_GROUP_ADMIN: 'add a group admin',
   ADD_LIST_ITEMS: 'add items to a list',
@@ -167,10 +167,18 @@ const QDN_SERVICE_SUMMARIES: Record<string, string> = {
   BLOG: 'This publishes blog content to QDN.',
 };
 
-const humanizeRequestType = (requestType?: string) => {
+export const getReadableRequestAction = (requestType?: string) => {
   if (!requestType) return 'make a change to your account';
   if (REQUEST_ACTION_LABELS[requestType]) return REQUEST_ACTION_LABELS[requestType];
   return 'make a change to your account';
+};
+
+const formatGroupType = (value?: string) => {
+  if (!value) return value;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '1' || normalized === 'public' || normalized === 'open') return 'Public';
+  if (normalized === '0' || normalized === 'private' || normalized === 'closed') return 'Private';
+  return value;
 };
 
 const sanitizeQuestionCopy = (value?: string) => {
@@ -199,6 +207,33 @@ const parseDetailRow = (value?: string): PermissionDetailRow | null => {
   return {
     value: trimmed,
   };
+};
+
+const trimTrailingZeros = (value: string) => {
+  if (!/^-?\d+(\.\d+)?$/u.test(value)) return value;
+  return value.replace(/\.?0+$/u, '');
+};
+
+const formatCurrencyValue = (value?: string, fallbackCurrency = 'QORT') => {
+  if (!value) return '';
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(-?\d+(?:\.\d+)?)(?:\s+([A-Z]+))?$/u);
+
+  if (!match) return trimmed;
+
+  const [, amount, currency] = match;
+  const normalizedAmount = trimTrailingZeros(amount);
+  const resolvedCurrency = currency || fallbackCurrency;
+  return resolvedCurrency ? `${normalizedAmount} ${resolvedCurrency}` : normalizedAmount;
+};
+
+const capitalizeSentence = (value?: string) => {
+  if (!value) return '';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+const buildFallbackActionSentence = (requestType?: string) => {
+  return capitalizeSentence(getReadableRequestAction(requestType));
 };
 
 const getDetailRowValue = (
@@ -234,12 +269,34 @@ const getJsonValue = (json: any, candidateKeys: string[]) => {
   return undefined;
 };
 
+const getPermissionsList = (message: MessageQortalRequestExtension) => {
+  const rawPermissions =
+    getJsonValue(message.json, ['permissions']) ??
+    message.technicalDetails
+      ?.flatMap((section) => section.rows || [])
+      .find((row) => row.label?.toLowerCase() === 'permissions')
+      ?.value;
+
+  if (Array.isArray(rawPermissions)) {
+    return rawPermissions.map((permission) => String(permission)).filter(Boolean);
+  }
+
+  if (typeof rawPermissions === 'string') {
+    return rawPermissions
+      .split(',')
+      .map((permission) => permission.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
 const buildTitle = (message: MessageQortalRequestExtension) => {
   if (message.summaryTitle) return message.summaryTitle;
 
   const sourceLabel = message.sourceLabel?.trim();
   const requestType = message.requestType;
-  const actionLabel = humanizeRequestType(requestType);
+  const actionLabel = getReadableRequestAction(requestType);
 
   if (sourceLabel) {
     return `${sourceLabel} wants to ${actionLabel}`;
@@ -261,9 +318,9 @@ const buildBody = (
 
   switch (requestType) {
     case 'GET_USER_ACCOUNT':
-      return 'This app can confirm your Qortal identity. It cannot send payments or publish data.';
+      return 'This confirms your Qortal identity for the application.\nThis action does not send a payment or publish data.';
     case 'SESSION_PERMISSIONS':
-      return 'Approved permissions can run automatically for this session only.';
+      return 'Approved permissions apply only during this session.';
     case 'ADD_FOREIGN_SERVER':
       return 'This adds a foreign server configuration to your Qortal environment.';
     case 'PUBLISH_QDN_RESOURCE':
@@ -272,11 +329,11 @@ const buildBody = (
         `This action will publish data to QDN using the ${serviceValue || 'selected'} service.`
       );
     case 'PUBLISH_MULTIPLE_QDN_RESOURCES':
-      return 'Multiple QDN resources will be published using your account.';
+      return 'Multiple QDN resources will be published using your account.\nResources may include private or encrypted data.';
     case 'SEND_COIN':
       return 'This sends funds from your wallet to the specified recipient.';
     case 'SIGN_TRANSACTION':
-      return 'This app wants your account to sign a transaction.';
+      return 'Review the transaction details before approving.';
     case 'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA':
       return 'This will send a payment and publish private encrypted data in the same action.';
     case 'REMOVE_FOREIGN_SERVER':
@@ -289,7 +346,7 @@ const buildBody = (
     case 'GET_USER_WALLET_TRANSACTIONS':
       return 'This gives the application access to wallet-related information from your Qortal account.';
     default:
-      return 'Review the details of this action before approving.';
+      return '';
   }
 };
 
@@ -309,46 +366,57 @@ const buildSummaryItems = (
   const recipientValue = getDetailRowValue(rows, 'to');
 
   if (requestType === 'GET_USER_ACCOUNT') {
-    return [
-      { value: 'This app can confirm your Qortal identity' },
-      { value: 'It cannot send payments' },
-      { value: 'It will not publish data' },
-    ];
+    return [{ value: 'Grant permissions for this session only' }];
   }
 
   if (requestType === 'SESSION_PERMISSIONS') {
+    const permissions = getPermissionsList(message);
     return [
-      {
-        value: 'Approved permissions can run automatically for this session only',
-      },
-      { value: 'These permissions stop when the session ends' },
+      ...(permissions.length
+        ? permissions.map((permission) => ({ value: capitalizeSentence(permission.replace(/_/g, ' ').toLowerCase()) }))
+        : [{ value: 'Grant permissions for this session only' }]),
     ];
   }
 
   if (requestType === 'ADD_FOREIGN_SERVER') {
+    const hostValue = getDetailRowValue(rows, 'host');
+    const portValue = getDetailRowValue(rows, 'port');
+    const protocolValue = getDetailRowValue(rows, 'protocol');
     return [
-      { value: 'This action will add a foreign server configuration' },
-      { value: 'Make sure you trust the server details below.' },
+      ...(hostValue ? [{ label: 'Host', value: hostValue }] : []),
+      ...(portValue ? [{ label: 'Port', value: portValue }] : []),
+      ...(protocolValue ? [{ label: 'Protocol', value: protocolValue }] : []),
+      ...(!hostValue && !portValue && !protocolValue
+        ? [{ value: 'Add a foreign server' }]
+        : []),
     ];
   }
 
   if (requestType === 'PUBLISH_QDN_RESOURCE') {
     return [
-      { value: 'This will publish data to QDN using your account' },
+      { value: 'Publish data to QDN using your account' },
       ...(serviceValue ? [{ label: 'Content type', value: formatServiceName(serviceValue) }] : []),
-      ...(nameValue ? [{ label: 'Publishing name', value: nameValue }] : []),
+      ...(nameValue ? [{ label: 'Name', value: nameValue }] : []),
+    ];
+  }
+
+  if (requestType === 'CREATE_GROUP') {
+    const typeValue = getDetailRowValue(rows, 'type');
+    return [
+      ...(message.highlightedText
+        ? [{ label: 'Group name', value: message.highlightedText.replace(/^group name:\s*/iu, '') }]
+        : []),
+      ...(typeValue ? [{ label: 'Type', value: formatGroupType(typeValue) }] : []),
+      { value: 'This action will create a group' },
     ];
   }
 
   if (requestType === 'PUBLISH_MULTIPLE_QDN_RESOURCES') {
-    const { resourceCount, includesPrivateData } = parsePublishMultipleSummary(message.html);
+    const { resourceCount } = parsePublishMultipleSummary(message.html);
     return [
-      { value: 'Multiple QDN resources will be published using your account' },
-      ...(includesPrivateData
-        ? [{ value: 'Some resources include private or encrypted data' }]
-        : []),
+      { value: 'Publish multiple QDN resources using your account' },
       ...(resourceCount > 0
-        ? [{ label: 'Resources in this request', value: `${resourceCount}` }]
+        ? [{ label: 'Resource count', value: `${resourceCount}` }]
         : []),
     ];
   }
@@ -356,7 +424,10 @@ const buildSummaryItems = (
   if (requestType === 'SEND_COIN') {
     return [
       ...(message.highlightedText ? [{ label: 'Amount', value: message.highlightedText }] : []),
-      ...(recipientValue ? [{ label: 'Recipient', value: recipientValue }] : []),
+      ...(recipientValue ? [{ label: 'Recipient address', value: recipientValue }] : []),
+      ...(!message.highlightedText && !recipientValue
+        ? [{ value: 'Send a payment' }]
+        : []),
     ];
   }
 
@@ -372,51 +443,53 @@ const buildSummaryItems = (
   }
 
   if (requestType === 'GET_WALLET_BALANCE') {
-    return [
-      { value: 'This app can view your wallet balance' },
-      ...(message.text1?.includes('{{ coin }}') ? [] : []),
-    ];
+    return [{ value: 'This app can view your wallet balance' }];
   }
 
   if (requestType === 'SIGN_TRANSACTION') {
     const txType = getJsonValue(message.json, ['type']);
     const recipient = getJsonValue(message.json, ['recipient', 'recipientAddress']);
     const amount = getJsonValue(message.json, ['amount', 'amountQort']);
-    return [
-      { value: 'This app wants your account to sign a transaction' },
+    const fieldRows = [
       ...(txType != null ? [{ label: 'Transaction type', value: String(txType) }] : []),
-      ...(recipient != null ? [{ label: 'Recipient', value: String(recipient) }] : []),
+      ...(recipient != null ? [{ label: 'Recipient address', value: String(recipient) }] : []),
       ...(amount != null ? [{ label: 'Amount', value: String(amount) }] : []),
     ];
+    return fieldRows.length > 0 ? fieldRows : [{ value: 'Sign a transaction' }];
   }
 
   if (requestType === 'REMOVE_FOREIGN_SERVER') {
-    return [
-      { value: 'This action will remove a saved foreign server configuration' },
-      { value: 'Review the server details below before approving' },
-    ];
+    return [{ value: 'This action will remove a saved foreign server configuration' }];
   }
 
   if (requestType === 'SET_CURRENT_FOREIGN_SERVER') {
-    return [
-      { value: 'This action will change the foreign server currently in use' },
-      { value: 'Review the server details below before approving' },
-    ];
+    return [{ value: 'This action will change the foreign server currently in use' }];
   }
 
   const summaryRows = rows.slice(0, message.highlightedText ? 1 : 2);
+
+  if (requestType === 'ADD_GROUP_ADMIN') {
+    return summaryRows.length > 0 ? summaryRows : [{ value: 'Add a group admin' }];
+  }
+
+  if (requestType === 'CREATE_GROUP') {
+    return summaryRows.length > 0 ? summaryRows : [{ value: 'Create a group' }];
+  }
+
+  if (requestType === 'MULTI_ASSET_PAYMENT_WITH_PRIVATE_DATA') {
+    return [
+      { value: 'Send a payment' },
+      { value: 'Publish private data' },
+    ];
+  }
+
   if (message.highlightedText) {
     return [{ value: message.highlightedText }, ...summaryRows];
   }
 
-  if (summaryRows.length > 0) {
-    return summaryRows;
-  }
-
-  return [
-    { value: 'This action will modify your Qortal account or data' },
-    { value: 'Review the technical details below before approving' },
-  ];
+  return summaryRows.length > 0
+    ? summaryRows
+    : [{ value: buildFallbackActionSentence(requestType) }];
 };
 
 const buildFeeItems = (
@@ -426,7 +499,10 @@ const buildFeeItems = (
   const feeItems: PermissionDetailRow[] = [];
 
   if (message.fee) {
-    feeItems.push({ label: 'Network fee', value: `${message.fee} QORT` });
+    feeItems.push({
+      label: message.requestType === 'CREATE_GROUP' ? 'Fee' : 'Network fee',
+      value: formatCurrencyValue(message.fee),
+    });
   }
 
   if (message.appFee) {
@@ -435,7 +511,7 @@ const buildFeeItems = (
         fee: message.appFee,
         postProcess: 'capitalizeFirstChar',
       }).split(':')[0] || 'App fee',
-      value: `${message.appFee} QORT`,
+      value: formatCurrencyValue(message.appFee),
     });
   }
 
@@ -445,7 +521,7 @@ const buildFeeItems = (
         fee: message.foreignFee,
         postProcess: 'capitalizeFirstChar',
       }).split(':')[0] || 'Foreign fee',
-      value: message.foreignFee,
+      value: formatCurrencyValue(message.foreignFee, ''),
     });
   }
 
@@ -479,6 +555,9 @@ const buildDetailsSections = (message: MessageQortalRequestExtension) => {
   );
 
   for (const section of message.technicalDetails || []) {
+    if (section.title?.trim().toLowerCase() === 'original message') {
+      continue;
+    }
     for (const row of section.rows || []) {
       pushTechnicalRow(row);
     }
@@ -506,16 +585,30 @@ const buildDetailsSections = (message: MessageQortalRequestExtension) => {
   return sections;
 };
 
+const normalizePresentationText = (value?: string) => {
+  return (value || '')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .replace(/[.!?]+$/u, '')
+    .toLowerCase();
+};
+
 export const buildPermissionPresentation = (
   message: MessageQortalRequestExtension,
   t: (key: string, options?: Record<string, unknown>) => string
 ): PermissionPresentation => {
+  const summaryItems = buildSummaryItems(message, t);
+  const body = buildBody(message, t);
+  const firstSummaryLine = summaryItems.find((item) => !item.label)?.value;
+  const resolvedBody =
+    normalizePresentationText(body) === normalizePresentationText(firstSummaryLine) ? '' : body;
+
   return {
     sourceLabel: message.sourceLabel,
     sourceKind: message.sourceKind || 'Application',
     title: buildTitle(message),
-    body: buildBody(message, t),
-    summaryItems: buildSummaryItems(message, t),
+    body: resolvedBody,
+    summaryItems,
     feeItems: buildFeeItems(message, t),
     detailsSections: buildDetailsSections(message),
   };

--- a/src/qortal/get.ts
+++ b/src/qortal/get.ts
@@ -459,6 +459,11 @@ const handleMessage = (event) => {
 
 window.addEventListener('message', handleMessage);
 
+const getPermissionSourceMeta = (appInfo, isFromExtension) => ({
+  sourceLabel: appInfo?.name || undefined,
+  sourceKind: appInfo?.name ? 'Q-App' : isFromExtension ? 'Extension' : 'Application',
+});
+
 async function getUserPermission(payload, isFromExtension) {
   return new Promise((resolve) => {
     const requestId = `qortalRequest_${Date.now()}`;
@@ -530,12 +535,14 @@ export const getUserAccount = async ({
           text1: i18n.t('question:permission.authenticate', {
             postProcess: 'capitalizeFirstChar',
           }),
+          requestType: 'GET_USER_ACCOUNT',
           checkbox1: {
             value: false,
             label: i18n.t('question:always_authenticate', {
               postProcess: 'capitalizeFirstChar',
             }),
           },
+          ...getPermissionSourceMeta(appInfo, isFromExtension),
         },
         isFromExtension
       );
@@ -634,6 +641,7 @@ export const sessionPermissions = async (data, isFromExtension, appInfo) => {
           appName: appInfo.name,
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SESSION_PERMISSIONS',
         text2: i18n.t('question:permission.session_permissions_description', {
           defaultValue:
             'The following permissions will be automatically granted for this session:',
@@ -656,6 +664,7 @@ export const sessionPermissions = async (data, isFromExtension, appInfo) => {
           postProcess: 'capitalizeFirstChar',
         }),
         isSessionPermission: true,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -1672,11 +1681,13 @@ export const publishQDNResource = async (
         text1: i18n.t('question:permission.publish_qdn', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'PUBLISH_QDN_RESOURCE',
         text2: `service: ${service}`,
         text3: `identifier: ${identifier || null}`,
         text4: `name: ${registeredName}`,
         fee: fee.fee,
         ...handleDynamicValues,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -1984,6 +1995,7 @@ export const publishMultipleQDNResources = async (
         text1: i18n.t('question:permission.publish_qdn', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'PUBLISH_MULTIPLE_QDN_RESOURCES',
         html: `
     <div style="max-height: 30vh; overflow-y: auto;">
     <style>
@@ -2043,6 +2055,7 @@ export const publishMultipleQDNResources = async (
       `,
         fee: +fee.fee * resources.length,
         ...handleDynamicValues,
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3456,6 +3469,7 @@ export const getUserWallet = async (data, isFromExtension, appInfo) => {
         text1: i18n.t('question:permission.get_wallet_info', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3463,6 +3477,7 @@ export const getUserWallet = async (data, isFromExtension, appInfo) => {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3608,12 +3623,14 @@ export const getWalletBalance = async (
           coin: data.coin, // TODO highlight coin in the modal
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_WALLET_BALANCE',
         checkbox1: {
           value: false,
           label: i18n.t('question:always_retrieve_balance', {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3863,6 +3880,7 @@ export const getUserWalletInfo = async (data, isFromExtension, appInfo) => {
         text1: i18n.t('question:permission.get_wallet_info', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET_INFO',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3870,6 +3888,7 @@ export const getUserWalletInfo = async (data, isFromExtension, appInfo) => {
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -3983,6 +4002,7 @@ export const getUserWalletTransactions = async (
         text1: i18n.t('question:permission.get_wallet_transactions', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'GET_USER_WALLET_TRANSACTIONS',
         highlightedText: `coin: ${data.coin}`,
         checkbox1: {
           value: false,
@@ -3990,6 +4010,7 @@ export const getUserWalletTransactions = async (
             postProcess: 'capitalizeFirstChar',
           }),
         },
+        ...getPermissionSourceMeta(appInfo, isFromExtension),
       },
       isFromExtension
     );
@@ -5090,6 +5111,7 @@ export const sendCoin = async (data, isFromExtension) => {
         text1: i18n.t('question:permission.send_coins', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SEND_COIN',
         text2: i18n.t('question:to_recipient', {
           recipient: recipient,
           postProcess: 'capitalizeFirstChar',
@@ -5097,6 +5119,7 @@ export const sendCoin = async (data, isFromExtension) => {
         highlightedText: `${amount} ${checkCoin}`,
         fee: fee,
         confirmCheckbox: true,
+        ...getPermissionSourceMeta(undefined, isFromExtension),
       },
       isFromExtension
     );
@@ -5147,12 +5170,14 @@ export const sendCoin = async (data, isFromExtension) => {
         text1: i18n.t('question:permission.send_coins', {
           postProcess: 'capitalizeFirstChar',
         }),
+        requestType: 'SEND_COIN',
         text2: i18n.t('question:to_recipient', {
           recipient: recipient,
           postProcess: 'capitalizeFirstChar',
         }),
         highlightedText: `${amount} ${checkCoin}`,
         foreignFee: `${fee} BTC`,
+        ...getPermissionSourceMeta(undefined, isFromExtension),
       },
       isFromExtension
     );
@@ -6357,12 +6382,14 @@ export const signTransaction = async (data, isFromExtension) => {
         : i18n.t('question:permission.sign_transaction', {
             postProcess: 'capitalizeFirstChar',
           }),
+      requestType: 'SIGN_TRANSACTION',
       highlightedText: i18n.t(
         'question:message.generic.read_transaction_carefully',
         { postProcess: 'capitalizeFirstChar' }
       ),
       text2: `Tx type: ${decodedData.type}`,
       json: decodedData,
+      ...getPermissionSourceMeta(undefined, isFromExtension),
     },
     isFromExtension
   );


### PR DESCRIPTION
**Before:**
<img width="490" height="322" alt="Screenshot 2026-04-12 045626" src="https://github.com/user-attachments/assets/c728e518-86ee-4a91-adb9-a3aa703f96a2" />

**After:**
<img width="563" height="523" alt="image" src="https://github.com/user-attachments/assets/43cf1710-3598-4fa6-8230-5964504167df" />

This PR improves the permission modal UI to make requests clearer and easier to understand for users.

What’s included:

- Human-readable titles for all request types
- Cleaner summaries based on actual request data
- Improved layout for complex requests like multi-publish
- Raw transaction payload is still visible but visually toned down
- Added local preview mode for testing

Scope:

- Covers all permission request types (40+ total)
- Core/high-impact requests (authentication, payments, publishing, signing) have custom, fully tailored summaries
- Remaining request types use a consistent fallback system with human-readable titles (e.g. “ban user”, “create group”, etc.) instead of generic wording

Important:

- No permission logic or behavior was changed
- UI-only improvement
- Existing request handling plugs into this presentation layer

Testing:

You can preview all request types locally:
http://127.0.0.1:5173/?permission-preview=1