### PR TITLE
Fix/postmessage

### DIFF
--- a/electron/src/setup.ts
+++ b/electron/src/setup.ts
@@ -1021,12 +1021,13 @@ export function setupContentSecurityPolicy(customScheme: string): void {
       ];
       const isHubShellRequest = requestUrl.startsWith(`${customScheme}://`);
       const inlineScriptSource = isHubShellRequest ? '' : " 'unsafe-inline'";
+      const evalScriptSource = isHubShellRequest ? '' : " 'unsafe-eval'";
 
       // Create the Content Security Policy (CSP) string
       const csp = `
     default-src 'self' ${frameSources.join(' ')};
     frame-src ${frameSources.join(' ')};
-    script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'${inlineScriptSource} ${frameSources.join(' ')};
+    script-src 'self' 'wasm-unsafe-eval'${evalScriptSource}${inlineScriptSource} ${frameSources.join(' ')};
     worker-src 'self' blob: data: ${frameSources.join(' ')};
     object-src 'self';
     connect-src 'self' blob: ${frameSources.join(' ')};

--- a/electron/src/setup.ts
+++ b/electron/src/setup.ts
@@ -1022,12 +1022,15 @@ export function setupContentSecurityPolicy(customScheme: string): void {
       const isHubShellRequest = requestUrl.startsWith(`${customScheme}://`);
       const inlineScriptSource = isHubShellRequest ? '' : " 'unsafe-inline'";
       const evalScriptSource = isHubShellRequest ? '' : " 'unsafe-eval'";
+      const wasmEvalScriptSource = isHubShellRequest
+        ? ''
+        : " 'wasm-unsafe-eval'";
 
       // Create the Content Security Policy (CSP) string
       const csp = `
     default-src 'self' ${frameSources.join(' ')};
     frame-src ${frameSources.join(' ')};
-    script-src 'self' 'wasm-unsafe-eval'${evalScriptSource}${inlineScriptSource} ${frameSources.join(' ')};
+    script-src 'self'${wasmEvalScriptSource}${evalScriptSource}${inlineScriptSource} ${frameSources.join(' ')};
     worker-src 'self' blob: data: ${frameSources.join(' ')};
     object-src 'self';
     connect-src 'self' blob: ${frameSources.join(' ')};

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -434,6 +434,10 @@ async function checkWebviewFocus() {
 
     // Listen for the response
     const handleMessage = (event) => {
+      if (event.origin !== window.location.origin || event.source !== window) {
+        return;
+      }
+
       if (event.data?.action === 'CHECK_FOCUS_RESPONSE') {
         clearTimeout(timeout);
         window.removeEventListener('message', handleMessage); // Clean up listener

--- a/src/components/Apps/AppViewer.tsx
+++ b/src/components/Apps/AppViewer.tsx
@@ -210,19 +210,19 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
 
     // Function to navigate back in iframe
     const navigateBackInIframe = async () => {
-      if (
-        iframeRef.current &&
-        iframeRef.current.contentWindow &&
-        history?.currentIndex > 0
-      ) {
+      const iframe = iframeRef.current;
+      if (iframe && iframe.contentWindow && history?.currentIndex > 0) {
         // Calculate the previous index and path
         const previousPageIndex = history.currentIndex - 1;
         const previousPath = history.customQDNHistoryPaths[previousPageIndex];
-        const targetOrigin = iframeRef.current
-          ? new URL(iframeRef.current.src).origin
-          : '*';
+        let targetOrigin;
+        try {
+          targetOrigin = new URL(iframe.src).origin;
+        } catch {
+          return;
+        }
         // Signal non-manual navigation
-        iframeRef.current.contentWindow.postMessage(
+        iframe.contentWindow.postMessage(
           { action: 'PERFORMING_NON_MANUAL', currentIndex: previousPageIndex },
           targetOrigin
         );
@@ -233,6 +233,8 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
         const navigationPromise = new Promise((resolve, reject) => {
           function handleNavigationSuccess(event) {
             if (
+              event.source === iframe.contentWindow &&
+              event.origin === targetOrigin &&
               event.data?.action === 'NAVIGATION_SUCCESS' &&
               event.data.path === previousPath
             ) {
@@ -248,7 +250,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
 
           // Timeout after 200ms if no response
           setTimeout(() => {
-            window.removeEventListener('message', handleNavigationSuccess);
+            frameWindow.removeEventListener('message', handleNavigationSuccess);
             reject(
               new Error(
                 t('core:message.error.navigation_timeout', {
@@ -257,11 +259,8 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
               )
             );
           }, 200);
-          const targetOrigin = iframeRef.current
-            ? new URL(iframeRef.current.src).origin
-            : '*';
           // Send the navigation command after setting up the listener and timeout
-          iframeRef.current.contentWindow.postMessage(
+          iframe.contentWindow.postMessage(
             {
               action: 'NAVIGATE_TO_PATH',
               path: previousPath,
@@ -308,15 +307,21 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
     const navigateToPathFunc = useCallback(
       async (e) => {
         const { path: targetPath = '' } = e.detail;
-        if (!iframeRef.current?.contentWindow) return;
+        const iframe = iframeRef.current;
+        if (!iframe?.contentWindow) return;
 
-        const targetOrigin = iframeRef.current
-          ? new URL(iframeRef.current.src).origin
-          : '*';
+        let targetOrigin;
+        try {
+          targetOrigin = new URL(iframe.src).origin;
+        } catch {
+          return;
+        }
 
         const navigationPromise = new Promise((resolve, reject) => {
           function handleNavigationSuccess(event) {
             if (
+              event.source === iframe.contentWindow &&
+              event.origin === targetOrigin &&
               event.data?.action === 'NAVIGATION_SUCCESS' &&
               event.data.path === targetPath
             ) {
@@ -334,7 +339,7 @@ export const AppViewer = forwardRef<HTMLIFrameElement, AppViewerProps>(
             frameWindow.removeEventListener('message', handleNavigationSuccess);
             reject(new Error('navigation_timeout'));
           }, 250);
-          iframeRef.current.contentWindow.postMessage(
+          iframe.contentWindow.postMessage(
             {
               action: 'NAVIGATE_TO_PATH',
               path: targetPath,

--- a/src/hooks/useQortalMessageListener.tsx
+++ b/src/hooks/useQortalMessageListener.tsx
@@ -673,7 +673,24 @@ export const useQortalMessageListener = (
     const listener = async (event) => {
       if (event?.data?.requestedHandler !== 'UI') return;
 
+      const appWindow = iframeRef.current?.contentWindow;
+      if (!appWindow || event.source !== appWindow) return;
+
+      let appOrigin = null;
+      try {
+        appOrigin = iframeRef.current?.src
+          ? new URL(iframeRef.current.src).origin
+          : null;
+      } catch {
+        return;
+      }
+      if (appOrigin && event.origin !== appOrigin) return;
+
+      const eventPort = event.ports?.[0];
+
       const sendMessageToRuntime = (message, eventPort) => {
+        if (!eventPort) return;
+
         let timeout: number = TIME_SECONDS_30_IN_MILLISECONDS;
         if (
           message?.action === 'PUBLISH_MULTIPLE_QDN_RESOURCES' &&
@@ -793,9 +810,11 @@ export const useQortalMessageListener = (
             payload: event.data,
             isExtension: true,
           },
-          event.ports[0]
+          eventPort
         );
       } else if (event?.data?.action === 'SAVE_FILE') {
+        if (!eventPort) return;
+
         try {
           await saveFile(event.data, null, true, {
             openSnackGlobal,
@@ -803,12 +822,12 @@ export const useQortalMessageListener = (
             infoSnackCustom,
             setInfoSnackCustom,
           });
-          event.ports[0].postMessage({
+          eventPort.postMessage({
             result: true,
             error: null,
           });
         } catch (error) {
-          event.ports[0].postMessage({
+          eventPort.postMessage({
             result: null,
             error: error?.message || 'Failed to save file',
           });
@@ -830,10 +849,10 @@ export const useQortalMessageListener = (
               payload: data,
               isExtension: true,
             },
-            event.ports[0]
+            eventPort
           );
         } else {
-          event.ports[0].postMessage({
+          eventPort?.postMessage({
             result: null,
             error: 'Failed to prepare data for publishing',
           });

--- a/src/qortal/get.ts
+++ b/src/qortal/get.ts
@@ -395,6 +395,10 @@ export const _voteOnPoll = async (
 const fileRequestResolvers = new Map();
 
 const handleFileMessage = (event) => {
+  if (event.origin !== window.location.origin || event.source !== window) {
+    return;
+  }
+
   const { action, requestId, result, error } = event.data;
 
   if (


### PR DESCRIPTION
Changes

Added source and origin validation for Q-App messages handled by useQortalMessageListener.
Added source and origin validation for NAVIGATION_SUCCESS listeners in AppViewer.
Fixed AppViewer navigation timeout cleanup to remove the listener from frameWindow.
Added same-origin/same-window checks for CHECK_FOCUS_RESPONSE.
Added same-origin/same-window checks for getFileFromIndexedDBResponse.
Removed 'unsafe-eval' from Electron hub-shell CSP responses, matching the existing 'unsafe-inline' shell behavior.
Preserved 'unsafe-eval' for non-shell contexts to avoid breaking hosted Q-Apps that currently depend on eval.